### PR TITLE
fix: :wrench: Bring secrets.py.example current with latest webapp cha…

### DIFF
--- a/secrets.py.example
+++ b/secrets.py.example
@@ -1,13 +1,16 @@
-# This file is where you keep secret settings, keep it safe and keep a backup.
+'''
+This file is where you keep secret settings, keep it safe and keep a backup.
+Please note, you can get an automatically generated version of this on the webapp
+'''
 
 secrets = {
     # WiFi network variables
     'ssid' : 'YOUR_WIFI_NETWORK',
     'password' : 'YOUR_WIFI_PASSWORD',
     # Hosted service variables
-    'broker' : 'mqtt.wificom.dev',
-    'mqtt_username' : 'YOUR_WIFICOM.DEV_EMAIL,
-    'mqtt_password' : 'YOUR_WIFICOM.DEV_ACCOUNT_PASSWORD',
+    'broker' : 'mqtt-production.wificom.dev',
+    'mqtt_username' : 'YOUR_WIFICOM.DEV_USERNAME,
+    'mqtt_password' : 'YOUR_WIFICOM.DEV_MQTT_AUTH_TOKEN',
     'user_uuid': 'FIND_ON_WIFICOM.DEV',
     'device_uuid': 'FIND_ON_WIFICOM.DEV',
 } 


### PR DESCRIPTION
secrets.py.example was out of date, it has been updated with this PR

Header comments were also updated to pass pylint (if .example were not there)