### PR TITLE
Feature/fix v2 loop bug

### DIFF
--- a/code.py
+++ b/code.py
@@ -125,6 +125,12 @@ led.duty_cycle = LED_DUTY_CYCLE_DIM
 
 while True:
 	time_start = time.monotonic()
+	if not platform_io.rtb_active and do_wifi:
+		while (time.monotonic() - time_start) < 5:
+			platform_io.loop()
+			if platform_io.get_subscribed_output(False) is not None:
+				break
+			time.sleep(0.1)
 	if serial.in_waiting != 0:
 		digirom = None
 		serial_bytes = serial.readline()
@@ -197,9 +203,3 @@ while True:
 
 		# Send to MQTT topic (acts as a ping also)
 		platform_io.send_digirom_output(last_output)
-
-		while (time.monotonic() - time_start) < 5:
-			platform_io.loop()
-			if platform_io.get_subscribed_output(False) is not None:
-				break
-			time.sleep(0.1)


### PR DESCRIPTION
This fixes the V2/X2/etc. (2 designations) bug.  This bug is found when sending one of the said codes and then attempting to send another code through the WiFiCom Web/API that you will be stuck with the old code.

This PR moves the loop so that it is caught by V1 and V2 codes.  Would be good to do some testing with this to ensure it doesn't break anything with RTBs.

Serial-only mode is also accounted for in this PR.