### PR TITLE
Issue #46 - Asset bundling using GitHub Action

### DIFF
--- a/.github/workflows/merge-libs-from-remote.yml
+++ b/.github/workflows/merge-libs-from-remote.yml
@@ -1,0 +1,106 @@
+name: Merge libs into release and branch, create artifacts for testing
+
+on:
+  release:
+    types: [created]
+  push:
+  pull_request:
+
+jobs:
+  merge_libs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set Env Variable
+        run: |
+          echo "FILENAME=release" >> $GITHUB_ENV
+
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Populate Variables
+        id: populate-vars
+        run: |
+          # Parse JSON data from sources.json
+          JSON_DATA=$(cat sources.json)
+
+          # Extract values from JSON data using jq
+          DMCOMM_COMMIT=$(echo $JSON_DATA | jq -r '.["dmcomm-python"].commit')
+          DMCOMM_URL=$(echo $JSON_DATA | jq -r '.["dmcomm-python"].url')
+          ADAFRUIT_VERSION=$(echo $JSON_DATA | jq -r '.adafruit_bundle.version')
+          ADAFRUIT_URL=$(echo $JSON_DATA | jq -r '.adafruit_bundle.url')
+          MINIMQTT_VERSION=$(echo $JSON_DATA | jq -r '.circuitpython_minimqtt.version')
+          MINIMQTT_URL=$(echo $JSON_DATA | jq -r '.circuitpython_minimqtt.url')
+
+          # Set environment variables
+          echo "DMCOMM_COMMIT=$DMCOMM_COMMIT" >> $GITHUB_ENV
+          echo "DMCOMM_URL=$DMCOMM_URL" >> $GITHUB_ENV
+          echo "ADAFRUIT_VERSION=$ADAFRUIT_VERSION" >> $GITHUB_ENV
+          echo "ADAFRUIT_URL=$ADAFRUIT_URL" >> $GITHUB_ENV
+          echo "MINIMQTT_VERSION=$MINIMQTT_VERSION" >> $GITHUB_ENV
+          echo "MINIMQTT_URL=$MINIMQTT_URL" >> $GITHUB_ENV
+
+      - name: Download and extract dmcomm-python
+        run: |
+          curl -LO $DMCOMM_URL
+          unzip -q $DMCOMM_COMMIT.zip -d dmcomm-python_lib 
+
+      - name: Download and extract Adafruit BUndle
+        run: |
+          curl -LO $ADAFRUIT_URL
+          unzip -q $ADAFRUIT_VERSION.zip -d adafruit_bundle
+
+      - name: Download and extract MiniMQTT
+        run: |
+          curl -LO $MINIMQTT_URL
+          unzip -q $MINIMQTT_VERSION -d minimqtt_lib      
+
+      - name: Merge libs
+        run: |
+          cp -r dmcomm-python_lib/dmcomm-python-$DMCOMM_COMMIT/lib/* lib/
+          cp -r adafruit_bundle/$ADAFRUIT_VERSION/lib/adafruit_bus_device lib/
+          cp -r adafruit_bundle/$ADAFRUIT_VERSION/lib/adafruit_display_text lib/
+          cp -r adafruit_bundle/$ADAFRUIT_VERSION/lib/adafruit_displayio_ssd1306.mpy lib/
+          cp -r adafruit_bundle/$ADAFRUIT_VERSION/lib/adafruit_requests.mpy lib/
+          cp -r adafruit_bundle/$ADAFRUIT_VERSION/lib/adafruit_esp32spi   lib/
+          cp -r minimqtt_lib/$MINIMQTT_VERSION/lib/* lib/
+
+      - name: Concatenate Licenses
+        run: |
+          echo "dmcomm-python" >> LICENSE
+          echo "https://github.com/dmcomm/dmcomm-python" >> LICENSE
+          curl https://raw.githubusercontent.com/dmcomm/dmcomm-python/main/LICENSE.txt >> LICENSE
+          echo -e "\n\n\nAdafruit_CircuitPython_Bundle" >> LICENSE
+          echo "https://github.com/adafruit/Adafruit_CircuitPython_Bundle" >> LICENSE
+          curl https://raw.githubusercontent.com/adafruit/Adafruit_CircuitPython_Bundle/main/LICENSE >> LICENSE
+          echo -e "\n\n\nAdafruit_CircuitPython_MiniMQTT" >> LICENSE
+          echo "https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT" >> LICENSE
+          curl https://raw.githubusercontent.com/adafruit/Adafruit_CircuitPython_MiniMQTT/main/LICENSE >> LICENSE
+      
+      - name: Create archive
+        id: create_archive
+        run: |
+          rm -f release.zip
+          rm -rf dmcomm-python_lib adafruit_bundle minimqtt_lib *.zip
+          zip -r release.zip --exclude=lib/wificom *
+          if [[ $GITHUB_REF =~ refs/tags/.* ]]; then
+            filename="wificom-lib_$(echo $GITHUB_REF | awk -F/ '{print $3}').zip"
+          else
+            filename="wificom-lib_$GITHUB_SHA.zip"
+          fi
+          current_value=$FILENAME
+          modified_value="$filename"
+          echo "FILENAME=$modified_value" >> $GITHUB_ENV
+          cp release.zip $filename
+        shell: /usr/bin/bash -e {0}
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: wificom_libs_merged.zip
+          path: release.zip
+
+      - name: Attach to release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ env.FILENAME }}

--- a/.github/workflows/merge-libs-from-remote.yml
+++ b/.github/workflows/merge-libs-from-remote.yml
@@ -61,8 +61,9 @@ jobs:
       - name: Cleanup folder
         id: cleanup_folder
         run: |
-          rm -f release.zip
+          rm -f release.zip .gitignore .pylintrc
           rm -rf sources_dmcomm_python sources_adafruit_bundle sources_circuitpython_minimqtt *.zip
+          rm -rf .git .github
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/merge-libs-from-remote.yml
+++ b/.github/workflows/merge-libs-from-remote.yml
@@ -74,7 +74,7 @@ jobs:
         id: create_archive
         run: |
           rm -rf sources_dmcomm_python sources_adafruit_bundle sources_circuitpython_minimqtt *.zip
-          zip -r release.zip --exclude=lib/wificom *
+          zip -r release.zip *
           if [[ $GITHUB_REF =~ refs/tags/.* ]]; then
             filename="wificom-lib_$(echo $GITHUB_REF | awk -F/ '{print $3}').zip"
           else

--- a/.github/workflows/merge-libs-from-remote.yml
+++ b/.github/workflows/merge-libs-from-remote.yml
@@ -18,70 +18,61 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Populate Variables
-        id: populate-vars
+      - name: JSON to variables
+        uses: antifree/json-to-variables@v1.0.1
+        with:
+          filename: 'sources.json'
+          prefix: sources
+
+      - name: Download and extract sources
         run: |
-          # Parse JSON data from sources.json
-          JSON_DATA=$(cat sources.json)
+          for key in dmcomm_python adafruit_bundle circuitpython_minimqtt; do
+            value=$(eval echo "\$sources_$key")
 
-          # Extract values from JSON data using jq
-          DMCOMM_COMMIT=$(echo $JSON_DATA | jq -r '.["dmcomm-python"].commit')
-          DMCOMM_URL=$(echo $JSON_DATA | jq -r '.["dmcomm-python"].url')
-          ADAFRUIT_VERSION=$(echo $JSON_DATA | jq -r '.adafruit_bundle.version')
-          ADAFRUIT_URL=$(echo $JSON_DATA | jq -r '.adafruit_bundle.url')
-          MINIMQTT_VERSION=$(echo $JSON_DATA | jq -r '.circuitpython_minimqtt.version')
-          MINIMQTT_URL=$(echo $JSON_DATA | jq -r '.circuitpython_minimqtt.url')
+            echo "Downloading and extracting $key..."
+            wget $value -O sources_$key.zip
+            unzip -q sources_$key.zip -d sources_$key
 
-          # Set environment variables
-          echo "DMCOMM_COMMIT=$DMCOMM_COMMIT" >> $GITHUB_ENV
-          echo "DMCOMM_URL=$DMCOMM_URL" >> $GITHUB_ENV
-          echo "ADAFRUIT_VERSION=$ADAFRUIT_VERSION" >> $GITHUB_ENV
-          echo "ADAFRUIT_URL=$ADAFRUIT_URL" >> $GITHUB_ENV
-          echo "MINIMQTT_VERSION=$MINIMQTT_VERSION" >> $GITHUB_ENV
-          echo "MINIMQTT_URL=$MINIMQTT_URL" >> $GITHUB_ENV
-
-      - name: Download and extract dmcomm-python
-        run: |
-          curl -LO $DMCOMM_URL
-          unzip -q $DMCOMM_COMMIT.zip -d dmcomm-python_lib 
-
-      - name: Download and extract Adafruit BUndle
-        run: |
-          curl -LO $ADAFRUIT_URL
-          unzip -q $ADAFRUIT_VERSION.zip -d adafruit_bundle
-
-      - name: Download and extract MiniMQTT
-        run: |
-          curl -LO $MINIMQTT_URL
-          unzip -q $MINIMQTT_VERSION -d minimqtt_lib      
+            echo "$key successfully downloaded and extracted."
+          done
 
       - name: Merge libs
         run: |
-          cp -r dmcomm-python_lib/dmcomm-python-$DMCOMM_COMMIT/lib/* lib/
-          cp -r adafruit_bundle/$ADAFRUIT_VERSION/lib/adafruit_bus_device lib/
-          cp -r adafruit_bundle/$ADAFRUIT_VERSION/lib/adafruit_display_text lib/
-          cp -r adafruit_bundle/$ADAFRUIT_VERSION/lib/adafruit_displayio_ssd1306.mpy lib/
-          cp -r adafruit_bundle/$ADAFRUIT_VERSION/lib/adafruit_requests.mpy lib/
-          cp -r adafruit_bundle/$ADAFRUIT_VERSION/lib/adafruit_esp32spi   lib/
-          cp -r minimqtt_lib/$MINIMQTT_VERSION/lib/* lib/
+          cp -r sources_dmcomm_python/*/lib/* lib/
+          cp -r sources_adafruit_bundle/*/lib/adafruit_bus_device lib/
+          cp -r sources_adafruit_bundle/*/lib/adafruit_display_text lib/
+          cp -r sources_adafruit_bundle/*/lib/adafruit_displayio_ssd1306.mpy lib/
+          cp -r sources_adafruit_bundle/*/lib/adafruit_requests.mpy lib/
+          cp -r sources_adafruit_bundle/*/lib/adafruit_esp32spi   lib/
+          cp -r sources_circuitpython_minimqtt/*/lib/* lib/
 
       - name: Concatenate Licenses
         run: |
-          echo "dmcomm-python" >> LICENSE
-          echo "https://github.com/dmcomm/dmcomm-python" >> LICENSE
-          curl https://raw.githubusercontent.com/dmcomm/dmcomm-python/main/LICENSE.txt >> LICENSE
-          echo -e "\n\n\nAdafruit_CircuitPython_Bundle" >> LICENSE
-          echo "https://github.com/adafruit/Adafruit_CircuitPython_Bundle" >> LICENSE
-          curl https://raw.githubusercontent.com/adafruit/Adafruit_CircuitPython_Bundle/main/LICENSE >> LICENSE
-          echo -e "\n\n\nAdafruit_CircuitPython_MiniMQTT" >> LICENSE
-          echo "https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT" >> LICENSE
-          curl https://raw.githubusercontent.com/adafruit/Adafruit_CircuitPython_MiniMQTT/main/LICENSE >> LICENSE
+          echo -e "\n\n\ndmcomm-python" >> LICENSE.txt
+          echo "https://github.com/dmcomm/dmcomm-python" >> LICENSE.txt
+          curl https://raw.githubusercontent.com/dmcomm/dmcomm-python/main/LICENSE.txt >> LICENSE.txt
+          echo -e "\n\n\nAdafruit_CircuitPython_Bundle" >> LICENSE.txt
+          echo "https://github.com/adafruit/Adafruit_CircuitPython_Bundle" >> LICENSE.txt
+          curl https://raw.githubusercontent.com/adafruit/Adafruit_CircuitPython_Bundle/main/LICENSE >> LICENSE.txt
+          echo -e "\n\n\nAdafruit_CircuitPython_MiniMQTT" >> LICENSE.txt
+          echo "https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT" >> LICENSE.txt
+          curl https://raw.githubusercontent.com/adafruit/Adafruit_CircuitPython_MiniMQTT/main/LICENSE >> LICENSE.txt
       
+      - name: Cleanup folder
+        id: cleanup_folder
+        run: |
+          rm -f release.zip
+          rm -rf sources_dmcomm_python sources_adafruit_bundle sources_circuitpython_minimqtt *.zip
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: wificom_libs_merged.zip
+          path: .
+
       - name: Create archive
         id: create_archive
         run: |
-          rm -f release.zip
-          rm -rf dmcomm-python_lib adafruit_bundle minimqtt_lib *.zip
+          rm -rf sources_dmcomm_python sources_adafruit_bundle sources_circuitpython_minimqtt *.zip
           zip -r release.zip --exclude=lib/wificom *
           if [[ $GITHUB_REF =~ refs/tags/.* ]]; then
             filename="wificom-lib_$(echo $GITHUB_REF | awk -F/ '{print $3}').zip"
@@ -93,11 +84,6 @@ jobs:
           echo "FILENAME=$modified_value" >> $GITHUB_ENV
           cp release.zip $filename
         shell: /usr/bin/bash -e {0}
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: wificom_libs_merged.zip
-          path: release.zip
 
       - name: Attach to release
         if: github.event_name == 'release'

--- a/.github/workflows/merge-libs-from-remote.yml
+++ b/.github/workflows/merge-libs-from-remote.yml
@@ -16,7 +16,7 @@ jobs:
           echo "FILENAME=release" >> $GITHUB_ENV
 
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Populate Variables
         id: populate-vars

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED] - 2023-02-12
+### Added
+- GitHub Action for combining third party libs into one archive for easy installation on microcontrollers
+### Changed
+- Updated README.md to reflect new installation process
+- Updated README.md to more accurately reflect current project status
+
 ## [0.7.0] - 2023-02-02
 ### Added
 - Ack for webapp sent commands

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Credits to the other great developers on the WiFiCom Discord.
     - Raspberry Pi Pico W: https://circuitpython.org/board/raspberry_pi_pico_w/
     - Arduino Nano RP2040 Connect: https://circuitpython.org/board/arduino_nano_rp2040_connect/
     - Pico with AirLift: https://circuitpython.org/board/raspberry_pi_pico/
-1. Download the latest release from releases page, you'll be looking for a file named "wificom-lib-VERSION.zip"
+1. Download the latest release from releases page, you'll be looking for a file named "wificom-lib_RELEASEVERSION.zip"
 1. Extract the zip and copy the contents into the root of the CIRCUITPY drive
 1. Copy the "secrets.py.example" to "secrets.py" and make changes to match your environment (you can get a prefilled version on the website https://wificom.dev)
 1. Modify "board_config.py" so that pinouts match your board, we advise using what you find as default but you can modify as needed for an unsupported board

--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ Credits to the other great developers on the WiFiCom Discord.
 ## Installation
 
 1. Check the version of WiFiCom you're installing in CHANGLOG.md to find the versions of dependencies we tested with it (other versions might not work)
-1. Install CircuitPython to the board
+1. Install CircuitPython 8.x to the board
+    - Raspberry Pi Pico W: https://circuitpython.org/board/raspberry_pi_pico_w/
+    - Arduino Nano RP2040 Connect: https://circuitpython.org/board/arduino_nano_rp2040_connect/
+    - Pico with AirLift: https://circuitpython.org/board/raspberry_pi_pico/
 1. Download the latest release from releases page, you'll be looking for a file named "wificom-lib-VERSION.zip"
 1. Extract the zip and copy the contents into the root of the CIRCUITPY drive
 1. Copy the "secrets.py.example" to "secrets.py" and make changes to match your environment (you can get a prefilled version on the website https://wificom.dev)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Credits to the other great developers on the WiFiCom Discord.
 - Visit https://dmcomm.github.io/guide/pi-pico/ for more information on this topic
 - Ensure you match pins on your supported board with those found in the example "board_config.py" file.  The pins have been optimized by BladeSabre for the boards found in "board_config.py".  If you have a different board, you will need to adjust the pins in the "board_config.py" file.
 
-## Installation
+## Initial Installation
 
 1. Check the version of WiFiCom you're installing in CHANGLOG.md to find the versions of dependencies we tested with it (other versions might not work)
 1. Install CircuitPython 8.x to the board
@@ -54,6 +54,16 @@ Credits to the other great developers on the WiFiCom Discord.
     10:59:47.046 -> Connected to MQTT Broker! 
     10:59:47.481 -> Subscribed to USERNAME/f/1111111111111111-2222222222222222/wificom-input with QOS level 0
     ```
+## Upgrade Firmware
+1. Backup your current files, in particular the following are commonly modified:
+    - secrets.py
+    - board_config.py
+    - digiroms.py
+1. Download the latest release from releases page, you'll be looking for a file named "wificom-lib_RELEASEVERSION.zip"
+1. Extract the zip and copy the contents into the root of the CIRCUITPY drive
+1. Compare contents of your modified files with the new files and make any neecessary changes
+1. Test that everything works, including connecting to WiFi and sending/receiving DigiRoms
+
 ## Screen
 There is an optional UI with a small screen and 3 buttons. Guide to follow.
 

--- a/README.md
+++ b/README.md
@@ -12,22 +12,22 @@ This library enables an RP2040 device using dmcomm-python (CircuitPython 8.x) to
 
 ## Credits
 
-This project was enabled by the great work, help, and input from BladeSabre.  Find the repo this one is built on top of at https://github.com/dmcomm/dmcomm-python.
+This project was enabled by the great work, help, input and code additions from BladeSabre.  Find the repo this one is built on top of at https://github.com/dmcomm/dmcomm-python.
 
 Credits to the other great developers on the WiFiCom Discord.
-
-A list of contributors will come as pull requests appear
 
 ## RP2040 Board Support
 
 ### Supported Boards
+- Raspberry Pi Pico W - RECOMMENDED OPTION
 - Arduino Nano Connect
-- Raspberry Pi Pico W
 - RP2040 with AirLift co-processor module
     - Pi Pico is the only tested board so far but others should work as well
 
 ### Unsupported Boards
 - RP2040 Challenger with WiFi Chip
+    - Issues with SSL with onboard chip; doesn't allow for secure requests
+- RP2040 Challenger with WiFi/BLE Chip
     - Issues with SSL with onboard chip; doesn't allow for secure requests
 
 ## Building a (WiFi) Pico-Com
@@ -38,25 +38,11 @@ A list of contributors will come as pull requests appear
 
 1. Check the version of WiFiCom you're installing in CHANGLOG.md to find the versions of dependencies we tested with it (other versions might not work)
 1. Install CircuitPython to the board
-1. Copy the "wificom" folder in this repository to your "lib" folder in your "CIRCUITPY" drive
-1. Copy the "code.py" file to your "CIRCUITPY" drive, replace existing "code.py"
-1. Copy the "boot.py" file into the "CIRCUITPY" drive, replace existing "boot.py"
-1. Copy the "board_config.py" file into the "CIRCUITPY" drive, replace existing "board_config.py"
-    - Keep the old version for reference if you've made modifications
-1. Copy the "digiroms.py" file into the "CIRCUITPY" drive, replace existing "digiroms.py"
-    - Keep the old version for reference if you've made modifications
-1. Install dmcomm-python into the "CIRCUITPY" drive
-    1. Copy the "lib/dmcomm" folder into the lib folder in your "CIRCUITPY" drive
-1. Install the following libs, find all of these in the libs folder of the CircuitPython [AdaFruit bundle](https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases) (8.x mpy archive)
-   1. adafruit_bus_device
-   1. adafruit_display_text
-   1. adafruit_esp32spi
-   1. adafruit_minimqtt - note you may need an older version of this
-   1. adafruit_displayio_ssd1306.mpy
-   1. adafruit_requests.mpy
-1. Copy the "secrets.py.example" to "secrets.py" and make changes to match your environment (you can get a prefilled version on the website)
-1. Modify "board_config.py" so that pinouts match your board, we advise using what you find as default but you can modify as needed
-1. Test that everything works, you should see the following output from Arduino IDE Serial Monitor
+1. Download the latest release from releases page, you'll be looking for a file named "wificom-lib-VERSION.zip"
+1. Extract the zip and copy the contents into the root of the CIRCUITPY drive
+1. Copy the "secrets.py.example" to "secrets.py" and make changes to match your environment (you can get a prefilled version on the website https://wificom.dev)
+1. Modify "board_config.py" so that pinouts match your board, we advise using what you find as default but you can modify as needed for an unsupported board
+1. Test that everything works, you should see the following output from Arduino IDE Serial Monitor (Mac/Linux) / MU Editor (Windows) after the screen comes up and you select "Wifi"
     ```
     10:59:45.103 -> dmcomm-python starting
     10:59:45.103 -> Connecting to WiFi network [WIFI_SSID]...
@@ -69,9 +55,9 @@ A list of contributors will come as pull requests appear
 There is an optional UI with a small screen and 3 buttons. Guide to follow.
 
 ## LED Indicator
+- Raspberry Pi Pico W: external LED is required
 - Arduino Nano RP2040 Connect: on-board orange LED
 - Raspberry Pi Pico: on-board green LED
-- Raspberry Pi Pico W: external LED is required
 
 ### LED Meanings
 - Blinking indicates connecting to WiFi and MQTT

--- a/sources.json
+++ b/sources.json
@@ -1,0 +1,14 @@
+{
+    "dmcomm-python": {
+        "commit": "fd8a61af84f79069cc9470b041d8a0fdda0aad8d",
+        "url": "https://github.com/dmcomm/dmcomm-python/archive/fd8a61af84f79069cc9470b041d8a0fdda0aad8d.zip"
+    },
+    "adafruit_bundle": {
+        "version": "adafruit-circuitpython-bundle-8.x-mpy-20221111",
+        "url": "https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/download/20221111/adafruit-circuitpython-bundle-8.x-mpy-20221111.zip"
+    },
+    "circuitpython_minimqtt": {
+        "version": "adafruit-circuitpython-minimqtt-8.x-mpy-5.5.1",
+        "url": "https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/releases/download/5.5.1/adafruit-circuitpython-minimqtt-8.x-mpy-5.5.1.zip"
+    }
+}

--- a/sources.json
+++ b/sources.json
@@ -1,14 +1,5 @@
 {
-    "dmcomm-python": {
-        "commit": "fd8a61af84f79069cc9470b041d8a0fdda0aad8d",
-        "url": "https://github.com/dmcomm/dmcomm-python/archive/fd8a61af84f79069cc9470b041d8a0fdda0aad8d.zip"
-    },
-    "adafruit_bundle": {
-        "version": "adafruit-circuitpython-bundle-8.x-mpy-20221111",
-        "url": "https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/download/20221111/adafruit-circuitpython-bundle-8.x-mpy-20221111.zip"
-    },
-    "circuitpython_minimqtt": {
-        "version": "adafruit-circuitpython-minimqtt-8.x-mpy-5.5.1",
-        "url": "https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/releases/download/5.5.1/adafruit-circuitpython-minimqtt-8.x-mpy-5.5.1.zip"
-    }
+    "dmcomm_python": "https://github.com/dmcomm/dmcomm-python/archive/fd8a61af84f79069cc9470b041d8a0fdda0aad8d.zip",
+    "adafruit_bundle": "https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/download/20221111/adafruit-circuitpython-bundle-8.x-mpy-20221111.zip",
+    "circuitpython_minimqtt": "https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/releases/download/5.5.1/adafruit-circuitpython-minimqtt-8.x-mpy-5.5.1.zip"
 }

--- a/sources.json
+++ b/sources.json
@@ -1,5 +1,5 @@
 {
-    "dmcomm_python": "https://github.com/dmcomm/dmcomm-python/archive/fd8a61af84f79069cc9470b041d8a0fdda0aad8d.zip",
+    "dmcomm_python": "https://github.com/dmcomm/dmcomm-python/archive/refs/tags/v0.3.0.zip",
     "adafruit_bundle": "https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/download/20221111/adafruit-circuitpython-bundle-8.x-mpy-20221111.zip",
     "circuitpython_minimqtt": "https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/releases/download/5.5.1/adafruit-circuitpython-minimqtt-8.x-mpy-5.5.1.zip"
 }


### PR DESCRIPTION
Brings in automated library bundling for our platform to run.  With this change users will download a wificom-lib_$(RELEASE TAG) archive to copy+paste.  This leaves only the "secrets.py" to be added afterwards.

- See artifacts for a sample run of this action
- Licenses are handled via a new file "LICENSE" with the three lib sources accounted for