### PR TITLE
Reboot if WiFi was run before

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Errors with secrets.py are caught, and displayed on the screen when attempting WiFi (other modes are able to run)
+- Reboot when entering WiFi mode for a second time to avoid reinitialization errors
 - Updated README.md to reflect new installation process
 - Updated README.md to more accurately reflect current project status
 

--- a/code.py
+++ b/code.py
@@ -8,6 +8,7 @@ import digitalio
 import displayio
 import microcontroller
 import pwmio
+import supervisor
 import usb_cdc
 
 # Light LED dimly while starting up. Doing this here because the following imports are slow.
@@ -160,6 +161,7 @@ def menu_reboot(mode):
 	ui.clear()
 	microcontroller.reset()
 
+done_wifi_before = False
 def run_wifi():
 	'''
 	Do the normal WiFiCom things.
@@ -180,6 +182,17 @@ def run_wifi():
 		while not ui.is_c_pressed():
 			pass
 		return
+
+	global done_wifi_before  # pylint: disable=global-statement
+	if done_wifi_before:
+		if startup_mode == nvm.MODE_DEV:
+			ui.display_text("Soft reboot...")
+			time.sleep(0.5)
+			ui.clear()
+			supervisor.reload()
+		else:
+			menu_reboot(nvm.MODE_WIFI)
+	done_wifi_before = True
 
 	# Connect to WiFi and MQTT
 	led.frequency = 1


### PR DESCRIPTION
I was thinking something like this, but it turns out there's a bigger problem, and reboots into WiFi mode aren't working on PicoW at all (including the usual case of switching from other modes).
```
Traceback (most recent call last):
  File "code.py", line 371, in <module>
  File "code.py", line 189, in run_wifi
  File "/lib/wificom/wifi_picow.py", line 35, in connect
ConnectionError: Unknown failure 205
```