### PR TITLE
Multiple wifi networks and retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed recommended `prong_in` on "Pi Pico + AirLift" from GP26 to GP22
 - Updated dmcomm-python to v0.5.0
 - Default mqtt server in secrets.py.example is now "mqtt.wificom.dev", changed from "mqtt-production.wificom.dev
+- Renamed secrets.py.example to secrets.example.py
 ### Removed
 - In secrets.py the values "ssid" and "password" are no longer used, removed from example
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Sound on/off config option
-- Multiple WiFi network support, configured through secrets.py, see secrets.py.example for updates
+- Multiple WiFi network support, configured through secrets.py, see secrets.example.py for updates
 - Retry each WiFi network up to 3 times each before moving on to the next
 - New sound "beep_wifi_failure" for when WiFi fails to connect
 ### Changed
 - Punchbag DigiROMs moved to `config.py` (`digiroms.py` removed)
 - Changed recommended `prong_in` on "Pi Pico + AirLift" from GP26 to GP22
 - Updated dmcomm-python to v0.5.0
-- Default mqtt server in secrets.py.example is now "mqtt.wificom.dev", changed from "mqtt-production.wificom.dev
+- Default mqtt server in secrets.example.py is now "mqtt.wificom.dev", changed from "mqtt-production.wificom.dev
 - Renamed secrets.py.example to secrets.example.py
 ### Removed
-- In secrets.py the values "ssid" and "password" are no longer used, removed from example
+- In secrets.py the values "ssid" and "password" are no longer used, removed from example.  Users must now use wifi_networks array instead.  This is a breaking change, you will get errors connecting to WiFi until you update your secrets.py file to match secrets.example.py
 
 ## [0.8.0] - 2023-02-15
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Multiple WiFi network support, configured through secrets.py, see secrets.py.example for updates
+- Retry each WiFi network up to 3 times each before moving on to the next
+- New sound "beep_wifi_failure" for when WiFi fails to connect
+### Changed
+- Default mqtt server in secrets.py.example is now "mqtt.wificom.dev", changed from "mqtt-production.wificom.dev
+### Removed
+- In secrets.py the values "ssid" and "password" are no longer used, removed from example
+
 ## [0.8.0] - 2023-02-15
 ### Added
 - Audio prompts for Pendulum X RTB

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Credits to the other great developers on the WiFiCom Discord.
 1. Download the latest release from releases page, you'll be looking for a file named "wificom-lib_RELEASEVERSION.zip"
 1. Extract the zip and copy the contents into the root of the CIRCUITPY drive
     - If you are using an unsupported board or custom circuit layout, then before copying to CIRCUITPY, modify "board_config.py" so that pinouts match your board
-1. Copy the "secrets.py.example" to "secrets.py" and make changes to match your environment (you can get a prefilled version on the website https://wificom.dev)
+1. Copy the "secrets.example.py" to "secrets.py" and make changes to match your environment (you can get a prefilled version on the website https://wificom.dev)
 1. Check that the system boots, then eject CIRCUITPY from the computer and replug the USB to enable the `boot.py` configuration
 1. Test that everything works, you should see the following output from Arduino IDE Serial Monitor (Mac/Linux) / MU Editor (Windows) after the screen comes up and you select "Wifi"
     ```

--- a/code.py
+++ b/code.py
@@ -203,18 +203,19 @@ def run_wifi():
 
 	wifi_loop_has_run = False
 
-	while mqtt_client is False:
-		ui.display_text("WiFi Failed\nHold C to reboot")
-		if not wifi_loop_has_run:
-			led.duty_cycle = 0
-			ui.beep_wifi_failure()
-			wifi_loop_has_run = True
+	if mqtt_client is None:
+		while True:
+			ui.display_text("WiFi Failed\nHold C to reboot")
+			if not wifi_loop_has_run:
+				led.duty_cycle = 0
+				ui.beep_wifi_failure()
+				wifi_loop_has_run = True
 
-		time.sleep(0.5)
+			time.sleep(0.5)
 
-		if ui.is_c_pressed():
-			time.sleep(2)
-			supervisor.reload()
+			if ui.is_c_pressed():
+				time.sleep(2)
+				supervisor.reload()
 
 	ui.display_text("Connecting to MQTT")
 	mqtt.connect_to_mqtt(mqtt_client)

--- a/code.py
+++ b/code.py
@@ -199,7 +199,7 @@ def run_wifi():
 	led.duty_cycle = 0x8000
 	ui.display_text("Connecting to WiFi")
 	wifi = board_config.WifiCls(**board_config.wifi_pins)
-	mqtt_client = wifi.connect()
+	mqtt_client = wifi.connect(ui, led)
 	ui.display_text("Connecting to MQTT")
 	mqtt.connect_to_mqtt(mqtt_client)
 	led.frequency = 1000

--- a/code.py
+++ b/code.py
@@ -201,8 +201,7 @@ def run_wifi():
 	wifi = board_config.WifiCls(**board_config.wifi_pins)
 	mqtt_client = wifi.connect()
 	if mqtt_client is None:
-		connection_failure_alert(mqtt_client, 'WiFi')
-
+		connection_failure_alert('WiFi')
 	ui.display_text("Connecting to MQTT")
 	mqtt.connect_to_mqtt(mqtt_client)
 	led.frequency = 1000
@@ -261,20 +260,19 @@ def run_wifi():
 				if time.monotonic() - time_start >= 5:
 					break
 				time.sleep(0.1)
-def connection_failure_alert(connection, failure_type):
+def connection_failure_alert(failure_type):
 	'''
 	Alert on connection failure.
 	'''
-	if connection is None:
-		led.duty_cycle = 0
-		# pylint: disable=consider-using-f-string
-		ui.display_text("{} Failed\nHold C to reboot".format(failure_type))
-		ui.beep_wifi_failure()
-		while True:
-			time.sleep(0.5)
-			if ui.is_c_pressed():
-				time.sleep(2)
-				supervisor.reload()
+	led.duty_cycle = 0
+	# pylint: disable=consider-using-f-string
+	ui.display_text("{} Failed\nHold C to reboot".format(failure_type))
+	ui.beep_wifi_failure()
+	while True:
+		time.sleep(0.5)
+		if ui.is_c_pressed():
+			time.sleep(2)
+			supervisor.reload()
 def run_serial():
 	'''
 	Run in serial mode.

--- a/code.py
+++ b/code.py
@@ -199,7 +199,23 @@ def run_wifi():
 	led.duty_cycle = 0x8000
 	ui.display_text("Connecting to WiFi")
 	wifi = board_config.WifiCls(**board_config.wifi_pins)
-	mqtt_client = wifi.connect(ui, led)
+	mqtt_client = wifi.connect()
+
+	wifi_loop_has_run = False
+
+	while mqtt_client is False:
+		ui.display_text("WiFi Failed\nHold C to reboot")
+		if not wifi_loop_has_run:
+			led.duty_cycle = 0
+			ui.beep_wifi_failure()
+			wifi_loop_has_run = True
+
+		time.sleep(0.5)
+
+		if ui.is_c_pressed():
+			time.sleep(2)
+			supervisor.reload()
+
 	ui.display_text("Connecting to MQTT")
 	mqtt.connect_to_mqtt(mqtt_client)
 	led.frequency = 1000

--- a/lib/wificom/import_secrets.py
+++ b/lib/wificom/import_secrets.py
@@ -3,8 +3,7 @@ import_secrets.py
 Import secrets into variables
 '''
 
-secrets_wifi_ssid = ""
-secrets_wifi_password = ""
+secrets_wireless_networks = ""
 secrets_user_uuid = ""
 secrets_device_uuid = ""
 secrets_mqtt_broker = ""
@@ -16,8 +15,7 @@ secrets_error_display = ""
 try:
 	from secrets import secrets
 
-	secrets_wifi_ssid = secrets["ssid"]
-	secrets_wifi_password = secrets["password"]
+	secrets_wireless_networks = secrets["wireless_networks"]
 	secrets_user_uuid = secrets["user_uuid"]
 	secrets_device_uuid = secrets["device_uuid"]
 	secrets_mqtt_broker = secrets["broker"]

--- a/lib/wificom/ui.py
+++ b/lib/wificom/ui.py
@@ -141,6 +141,13 @@ class UserInterface:
 		'''
 		f = self.audio_base_freq
 		self._speaker.play([(f, 0.15), (f/2, 0.15)])
+	def beep_wifi_failure(self):
+		'''
+		Beep for WiFi connection failure.
+		'''
+		for _ in range(3):
+			self.beep_error()
+			time.sleep(0.8)
 	def menu(self, options, results, cancel_result):
 		'''
 		Display a menu with the specified options and return the corresponding result.

--- a/lib/wificom/wifi_nina.py
+++ b/lib/wificom/wifi_nina.py
@@ -28,7 +28,7 @@ class Wifi:
 		self.esp = adafruit_esp32spi.ESP_SPIcontrol(self.spi, self.esp32_cs, self.esp32_ready, \
 			 self.esp32_reset)
 		socket.set_interface(self.esp)
-	# pylint: disable=unused-argument,invalid-name
+	# pylint: disable=unused-argument,invalid-name,inconsistent-return-statements
 	def connect(self, ui = None, led = None):
 		'''
 		Connect to a supported board's WiFi network
@@ -49,7 +49,6 @@ class Wifi:
 					MQTT.set_socket(socket, self.esp)
 
 					return mqtt_client
-				#pylint: disable=broad-except, invalid-name
+				#pylint: disable=broad-except,invalid-name
 				except Exception as e:
 					print("Failed to connect: ", e)
-					return False

--- a/lib/wificom/wifi_nina.py
+++ b/lib/wificom/wifi_nina.py
@@ -52,4 +52,4 @@ class Wifi:
 				#pylint: disable=broad-except,invalid-name
 				except Exception as e:
 					print("Failed to connect: ", e)
-		return False
+		return None

--- a/lib/wificom/wifi_nina.py
+++ b/lib/wificom/wifi_nina.py
@@ -29,7 +29,7 @@ class Wifi:
 			 self.esp32_reset)
 		socket.set_interface(self.esp)
 	# pylint: disable=unused-argument,invalid-name,inconsistent-return-statements
-	def connect(self, ui = None, led = None):
+	def connect(self):
 		'''
 		Connect to a supported board's WiFi network
 		'''
@@ -52,3 +52,4 @@ class Wifi:
 				#pylint: disable=broad-except,invalid-name
 				except Exception as e:
 					print("Failed to connect: ", e)
+		return False

--- a/lib/wificom/wifi_nina.py
+++ b/lib/wificom/wifi_nina.py
@@ -32,12 +32,11 @@ class Wifi:
 		'''
 		Connect to a supported board's WiFi network
 		'''
-		for _ in secrets_wireless_networks:
-			#pylint: disable=unused-variable
-			for i in range(3):
+		for network in secrets_wireless_networks:
+			for _ in range(3):
 				try:
-					print("Connecting to", _['ssid'])
-					self.esp.connect_AP(_['ssid'], _['password'])
+					print("Connecting to", network['ssid'])
+					self.esp.connect_AP(network['ssid'], network['password'])
 
 					mqtt_client = MQTT.MQTT(
 						broker=secrets_mqtt_broker,

--- a/lib/wificom/wifi_nina.py
+++ b/lib/wificom/wifi_nina.py
@@ -28,17 +28,16 @@ class Wifi:
 		self.esp = adafruit_esp32spi.ESP_SPIcontrol(self.spi, self.esp32_cs, self.esp32_ready, \
 			 self.esp32_reset)
 		socket.set_interface(self.esp)
-	# pylint: disable=unused-argument,invalid-name,inconsistent-return-statements
 	def connect(self):
 		'''
 		Connect to a supported board's WiFi network
 		'''
-		for network in secrets_wireless_networks:
+		for _ in secrets_wireless_networks:
 			#pylint: disable=unused-variable
 			for i in range(3):
 				try:
-					print("Connecting to", network['ssid'])
-					self.esp.connect_AP(network['ssid'], network['password'])
+					print("Connecting to", _['ssid'])
+					self.esp.connect_AP(_['ssid'], _['password'])
 
 					mqtt_client = MQTT.MQTT(
 						broker=secrets_mqtt_broker,
@@ -51,5 +50,5 @@ class Wifi:
 					return mqtt_client
 				#pylint: disable=broad-except,invalid-name
 				except Exception as e:
-					print("Failed to connect: ", e)
+					print(f"Failed to connect: {type(e)} - {e}")
 		return None

--- a/lib/wificom/wifi_picow.py
+++ b/lib/wificom/wifi_picow.py
@@ -56,7 +56,7 @@ class Wifi:
 			wifi.radio.stop_scanning_networks()
 
 			if not connected:
-				return False
+				return None
 
 			pool = socketpool.SocketPool(wifi.radio)
 

--- a/lib/wificom/wifi_picow.py
+++ b/lib/wificom/wifi_picow.py
@@ -44,6 +44,7 @@ class Wifi:
 							wifi.radio.connect(network['ssid'], network['password'])
 						except ConnectionError as e:
 							print("Failed to connect, retrying: ", e)
+						#pylint: disable=no-else-break
 						if wifi.radio.ipv4_address is not None:
 							connected = True
 							break

--- a/lib/wificom/wifi_picow.py
+++ b/lib/wificom/wifi_picow.py
@@ -3,15 +3,15 @@ wifi_picow.py
 Handles the WiFi connnection for Pico W.
 '''
 import ssl
-from wificom.import_secrets import secrets_wifi_ssid, \
-	secrets_wifi_password, \
+import time
+from wificom.import_secrets import secrets_wireless_networks, \
 	secrets_mqtt_broker, \
 	secrets_mqtt_username, \
 	secrets_mqtt_password
 import wifi
 import socketpool
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
-
+import supervisor
 
 class Wifi:
 	'''
@@ -21,18 +21,55 @@ class Wifi:
 	def __init__(self):
 		return
 
-	def connect(self):
+	# pylint: disable=invalid-name
+	def connect(self, ui, led):
 		'''
 		Connect to a supported board's WiFi network
 		'''
-		print("Connecting to WiFi network [" + secrets_wifi_ssid + "]...")
 
-		secrets_payload = {
-			'ssid': secrets_wifi_ssid,
-			'password': secrets_wifi_password
-		}
+		# Initialize networking
+		num_retries = 1
+		connected = False
+		while not connected:
+			print("Scanning for networks...")
+			for network in secrets_wireless_networks:
+				retries = num_retries
+				while retries > 0:
+					#pylint: disable=consider-using-set-comprehension
+					found = set([wifi.ssid for wifi in wifi.radio.start_scanning_networks()])
+					if network['ssid'] in found:
+						print(f"Connecting to {network['ssid']} \
+							(attempt {num_retries-retries+1} of {num_retries})...")
+						try:
+							wifi.radio.connect(network['ssid'], network['password'])
+						except ConnectionError as e:
+							print("Failed to connect, retrying: ", e)
+						if wifi.radio.ipv4_address is not None:
+							connected = True
+							break
+					else:
+						retries -= 1
+				if connected:
+					break
+			if not connected:
+				while not ui.is_c_pressed():
+					ui.display_text("WiFi Failed\nHold C to change")
+					ui.beep_error()
+					time.sleep(0.7)
+					ui.beep_error()
+					time.sleep(0.7)
+					ui.beep_error()
+					while True:
+						led.frequency = 1
+						led.duty_cycle = 0x7d0
 
-		wifi.radio.connect(secrets_payload["ssid"], secrets_payload["password"])
+				ui.beep_cancel()
+				time.sleep(0.5)
+				supervisor.reload()
+
+
+
+		wifi.radio.stop_scanning_networks()
 
 		pool = socketpool.SocketPool(wifi.radio)
 

--- a/lib/wificom/wifi_picow.py
+++ b/lib/wificom/wifi_picow.py
@@ -30,16 +30,16 @@ class Wifi:
 		connected = False
 		while not connected:
 			print("Scanning for networks...")
-			for _ in secrets_wireless_networks:
+			for network in secrets_wireless_networks:
 				retries = num_retries
 				while retries > 0:
 					#pylint: disable=consider-using-set-comprehension
 					found = set([wifi.ssid for wifi in wifi.radio.start_scanning_networks()])
-					if _['ssid'] in found:
-						print(f"Connecting to {_['ssid']} \
+					if network['ssid'] in found:
+						print(f"Connecting to {network['ssid']} \
 							(attempt {num_retries-retries+1} of {num_retries})...")
 						try:
-							wifi.radio.connect(_['ssid'], _['password'])
+							wifi.radio.connect(network['ssid'], network['password'])
 						except ConnectionError as e:
 							print("Failed to connect, retrying: ", e)
 						#pylint: disable=no-else-break

--- a/lib/wificom/wifi_picow.py
+++ b/lib/wificom/wifi_picow.py
@@ -30,16 +30,16 @@ class Wifi:
 		connected = False
 		while not connected:
 			print("Scanning for networks...")
-			for network in secrets_wireless_networks:
+			for _ in secrets_wireless_networks:
 				retries = num_retries
 				while retries > 0:
 					#pylint: disable=consider-using-set-comprehension
 					found = set([wifi.ssid for wifi in wifi.radio.start_scanning_networks()])
-					if network['ssid'] in found:
-						print(f"Connecting to {network['ssid']} \
+					if _['ssid'] in found:
+						print(f"Connecting to {_['ssid']} \
 							(attempt {num_retries-retries+1} of {num_retries})...")
 						try:
-							wifi.radio.connect(network['ssid'], network['password'])
+							wifi.radio.connect(_['ssid'], _['password'])
 						except ConnectionError as e:
 							print("Failed to connect, retrying: ", e)
 						#pylint: disable=no-else-break

--- a/lib/wificom/wifi_picow.py
+++ b/lib/wificom/wifi_picow.py
@@ -28,7 +28,7 @@ class Wifi:
 		'''
 
 		# Initialize networking
-		num_retries = 1
+		num_retries = 3
 		connected = False
 		while not connected:
 			print("Scanning for networks...")

--- a/lib/wificom/wifi_picow.py
+++ b/lib/wificom/wifi_picow.py
@@ -44,7 +44,6 @@ class Wifi:
 							wifi.radio.connect(network['ssid'], network['password'])
 						except ConnectionError as e:
 							print("Failed to connect, retrying: ", e)
-						#pylint: disable=no-else-break
 						if wifi.radio.ipv4_address is not None:
 							connected = True
 							break
@@ -62,9 +61,8 @@ class Wifi:
 					ui.beep_error()
 					time.sleep(0.7)
 					ui.beep_error()
-					while True:
-						led.frequency = 1
-						led.duty_cycle = 0x7d0
+					led.frequency = 1
+					led.duty_cycle = 0x7d0
 
 				ui.beep_cancel()
 				time.sleep(0.5)

--- a/lib/wificom/wifi_picow.py
+++ b/lib/wificom/wifi_picow.py
@@ -44,9 +44,12 @@ class Wifi:
 							wifi.radio.connect(network['ssid'], network['password'])
 						except ConnectionError as e:
 							print("Failed to connect, retrying: ", e)
+						#pylint: disable=no-else-break
 						if wifi.radio.ipv4_address is not None:
 							connected = True
 							break
+						else:
+							retries -= 1
 					else:
 						retries -= 1
 				if connected:

--- a/secrets.example.py
+++ b/secrets.example.py
@@ -16,4 +16,4 @@ secrets = {
 	'mqtt_password' : 'YOUR_WIFICOM.DEV_MQTT_AUTH_TOKEN',
 	'user_uuid': 'FIND_ON_WIFICOM.DEV',
 	'device_uuid': 'FIND_ON_WIFICOM.DEV',
-} 
+}

--- a/secrets.example.py
+++ b/secrets.example.py
@@ -8,7 +8,7 @@ secrets = {
 	"wireless_networks":[
 		{'ssid': 'FIRST_SSID', 'password': 'YOURSECUREPASSWORD'},
 		# {'ssid': 'SECOND_SSID', 'password': 'YOURSECUREPASSWORD'}, # Example of an additional network
-		# {'ssid': 'THRID_SSID', 'password': 'YOURSECUREPASSWORD'}, # Example of an additional network
+		# {'ssid': 'THIRD_SSID', 'password': 'YOURSECUREPASSWORD'}, # Example of an additional network
 	],
 	# Hosted service variables
 	'broker' : 'mqtt.wificom.dev',

--- a/secrets.py.example
+++ b/secrets.py.example
@@ -7,8 +7,8 @@ secrets = {
     # WiFi network variables
     "wireless_networks":[
         {'ssid': 'FIRST_SSID', 'password': 'YOURSECUREPASSWORD'},
-        {'ssid': 'SECOND_SSID', 'password': 'YOURSECUREPASSWORD'},
-        # {'ssid': 'THRID_SSDID', 'password': 'YOURSECUREPASSWORD'}, # Example of additional network  
+        # {'ssid': 'SECOND_SSID', 'password': 'YOURSECUREPASSWORD'}, # Example of an additional network
+        # {'ssid': 'THRID_SSID', 'password': 'YOURSECUREPASSWORD'}, # Example of an additional network
     ],
     # Hosted service variables
     'broker' : 'mqtt.wificom.dev',

--- a/secrets.py.example
+++ b/secrets.py.example
@@ -5,11 +5,14 @@ Please note, you can get an automatically generated version of this on the webap
 
 secrets = {
     # WiFi network variables
-    'ssid' : 'YOUR_WIFI_NETWORK',
-    'password' : 'YOUR_WIFI_PASSWORD',
+    "wireless_networks":[
+        {'ssid': 'FIRST_SSID', 'password': 'YOURSECUREPASSWORD'},
+        {'ssid': 'SECOND_SSID', 'password': 'YOURSECUREPASSWORD'},
+        # {'ssid': 'THRID_SSDID', 'password': 'YOURSECUREPASSWORD'}, # Example of additional network  
+    ],
     # Hosted service variables
-    'broker' : 'mqtt-production.wificom.dev',
-    'mqtt_username' : 'YOUR_WIFICOM.DEV_USERNAME,
+    'broker' : 'mqtt.wificom.dev',
+    'mqtt_username' : 'YOUR_WIFICOM.DEV_USERNAME',
     'mqtt_password' : 'YOUR_WIFICOM.DEV_MQTT_AUTH_TOKEN',
     'user_uuid': 'FIND_ON_WIFICOM.DEV',
     'device_uuid': 'FIND_ON_WIFICOM.DEV',

--- a/secrets.py.example
+++ b/secrets.py.example
@@ -4,16 +4,16 @@ Please note, you can get an automatically generated version of this on the webap
 '''
 
 secrets = {
-    # WiFi network variables
-    "wireless_networks":[
-        {'ssid': 'FIRST_SSID', 'password': 'YOURSECUREPASSWORD'},
-        # {'ssid': 'SECOND_SSID', 'password': 'YOURSECUREPASSWORD'}, # Example of an additional network
-        # {'ssid': 'THRID_SSID', 'password': 'YOURSECUREPASSWORD'}, # Example of an additional network
-    ],
-    # Hosted service variables
-    'broker' : 'mqtt.wificom.dev',
-    'mqtt_username' : 'YOUR_WIFICOM.DEV_USERNAME',
-    'mqtt_password' : 'YOUR_WIFICOM.DEV_MQTT_AUTH_TOKEN',
-    'user_uuid': 'FIND_ON_WIFICOM.DEV',
-    'device_uuid': 'FIND_ON_WIFICOM.DEV',
+	# WiFi network variables
+	"wireless_networks":[
+		{'ssid': 'FIRST_SSID', 'password': 'YOURSECUREPASSWORD'},
+		# {'ssid': 'SECOND_SSID', 'password': 'YOURSECUREPASSWORD'}, # Example of an additional network
+		# {'ssid': 'THRID_SSID', 'password': 'YOURSECUREPASSWORD'}, # Example of an additional network
+	],
+	# Hosted service variables
+	'broker' : 'mqtt.wificom.dev',
+	'mqtt_username' : 'YOUR_WIFICOM.DEV_USERNAME',
+	'mqtt_password' : 'YOUR_WIFICOM.DEV_MQTT_AUTH_TOKEN',
+	'user_uuid': 'FIND_ON_WIFICOM.DEV',
+	'device_uuid': 'FIND_ON_WIFICOM.DEV',
 } 


### PR DESCRIPTION
- Modifies the default secrets.py file to use an array of wifi networks
   - The list goes from top to bottom when attempting to connect
 - Screenless units are accounted for

**Wireless Network Feedback**
- Screened unit, beeps 3x on failure, then displays "WiFi Failed\nHold C to reboot", LED goes out.  Holding C for ~3s will reboot the unit using a reload
- Screenless/speakerless unit, LED goes out, need to reboot to retry

Resolves #57