### PR TITLE
Compile libs to mpy

### DIFF
--- a/.github/workflows/merge-libs-compile-circuitpython-files.yml
+++ b/.github/workflows/merge-libs-compile-circuitpython-files.yml
@@ -1,40 +1,22 @@
-name: Merge libs into release and branch, create artifacts for testing
+name: Merge libs and compile CircuitPython files
 
 on:
-  release:
-    types: [created]
   push:
-  pull_request:
+    paths:
+      - '**/lib/**/*.py'
 
 jobs:
-  merge_libs:
+  merge_and_compile:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set Env Variable
-        run: |
-          echo "FILENAME=release" >> $GITHUB_ENV
+      - uses: actions/checkout@v2
 
-      - name: Checkout repo
-        uses: actions/checkout@v3
+      - name: Install required packages
+        run: sudo apt-get update && sudo apt-get -y install python3 python3-pip
 
-      - name: JSON to variables
-        uses: antifree/json-to-variables@v1.0.1
-        with:
-          filename: 'sources.json'
-          prefix: sources
-
-      - name: Download and extract sources
-        run: |
-          for key in dmcomm_python adafruit_bundle circuitpython_minimqtt; do
-            value=$(eval echo "\$sources_$key")
-
-            echo "Downloading and extracting $key..."
-            wget $value -O sources_$key.zip
-            unzip -q sources_$key.zip -d sources_$key
-
-            echo "$key successfully downloaded and extracted."
-          done
+      - name: Install build-mpy
+        run: python3 -m pip install build-mpy
 
       - name: Merge libs
         run: |
@@ -45,6 +27,17 @@ jobs:
           cp -r sources_adafruit_bundle/*/lib/adafruit_requests.mpy lib/
           cp -r sources_adafruit_bundle/*/lib/adafruit_esp32spi   lib/
           cp -r sources_circuitpython_minimqtt/*/lib/* lib/
+
+      - name: Compile CircuitPython files to .mpy files
+        run: |
+          for file in $(find ./lib -type f -name "*.py"); do
+            echo "Compiling $file..."
+            python3 -m build_mpy --output-dir=./lib $file
+          done
+
+      - name: Delete original .py files in lib/ folder
+        run: |
+          find ./lib -type f -name "*.py" -delete
 
       - name: Concatenate Licenses
         run: |
@@ -57,21 +50,8 @@ jobs:
           echo -e "\n\n\nAdafruit_CircuitPython_MiniMQTT" >> LICENSE.txt
           echo "https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT" >> LICENSE.txt
           curl https://raw.githubusercontent.com/adafruit/Adafruit_CircuitPython_MiniMQTT/main/LICENSE >> LICENSE.txt
-      
-      - name: Cleanup folder
-        id: cleanup_folder
-        run: |
-          rm -f release.zip .gitignore .pylintrc
-          rm -rf sources_dmcomm_python sources_adafruit_bundle sources_circuitpython_minimqtt *.zip
-          rm -rf .git .github
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: wificom_libs_merged.zip
-          path: .
 
       - name: Create archive
-        id: create_archive
         run: |
           rm -rf sources_dmcomm_python sources_adafruit_bundle sources_circuitpython_minimqtt *.zip
           zip -r release.zip *
@@ -80,12 +60,15 @@ jobs:
           else
             filename="wificom-lib_$GITHUB_SHA.zip"
           fi
-          current_value=$FILENAME
-          modified_value="$filename"
-          echo "FILENAME=$modified_value" >> $GITHUB_ENV
-          cp release.zip $filename
+          mv release.zip $filename
+          echo "::set-output name=filename::$filename"
         shell: /usr/bin/bash -e {0}
 
+      - uses: actions/upload-artifact@v2
+        with:
+          name: wificom_libs_merged.zip
+          path: .
+          
       - name: Attach to release
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/merge-libs-compile-circuitpython-files.yml
+++ b/.github/workflows/merge-libs-compile-circuitpython-files.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Remove unnecessary files
         run: |
-          rm -rf sources_dmcomm_python sources_adafruit_bundle sources_circuitpython_minimqtt *.zip
+          rm -rf sources_dmcomm_python sources_adafruit_bundle sources_circuitpython_minimqtt *.zip .git .github .gitignore .pylintrc
   
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/merge-libs-compile-circuitpython-files.yml
+++ b/.github/workflows/merge-libs-compile-circuitpython-files.yml
@@ -48,13 +48,24 @@ jobs:
       - name: Compile CircuitPython files to .mpy files
         run: |
           for file in $(find ./lib -type f -name "*.py"); do
-            echo "Compiling $file..."
-            mpy-cross $file
+            if [ -s $file ]; then
+              echo "Compiling $file..."
+              mpy-cross $file
+            else
+              echo "Skipping $file because it is empty."
+            fi
           done
 
-      - name: Delete original .py files in lib/ folder
+      - name: Delete original .py files in lib/ folder, except for empty ones
         run: |
-          find ./lib -type f -name "*.py" -delete
+          find ./lib -type f -name "*.py" | while read file; do
+            if [ -s $file ]; then
+              echo "Deleting $file because it is not empty."
+              rm $file
+            else
+              echo "Skipping $file because it is empty."
+            fi
+          done
 
       - name: Concatenate Licenses
         run: |

--- a/.github/workflows/merge-libs-compile-circuitpython-files.yml
+++ b/.github/workflows/merge-libs-compile-circuitpython-files.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install required packages
         run: sudo apt-get update && sudo apt-get -y install python3 python3-pip
 
-      - name: Install Adafruit-ampy
+      - name: Install mpy-cross
         run: python3 -m pip install mpy-cross
 
       - name: JSON to variables

--- a/.github/workflows/merge-libs-compile-circuitpython-files.yml
+++ b/.github/workflows/merge-libs-compile-circuitpython-files.yml
@@ -16,8 +16,10 @@ jobs:
       - name: Install required packages
         run: sudo apt-get update && sudo apt-get -y install python3 python3-pip
 
-      - name: Install mpy-cross
-        run: python3 -m pip install mpy-cross
+      - name: Download mpy-cross
+        run: |
+          wget https://adafruit-circuit-python.s3.amazonaws.com/bin/mpy-cross/mpy-cross.static-amd64-linux-8.0.0
+          chmod +x mpy-cross.static-amd64-linux-8.0.0
 
       - name: JSON to variables
         uses: antifree/json-to-variables@v1.0.1
@@ -50,7 +52,7 @@ jobs:
           for file in $(find ./lib -type f -name "*.py"); do
             if [ -s $file ]; then
               echo "Compiling $file..."
-              mpy-cross $file
+              ./mpy-cross.static-amd64-linux-8.0.0 $file
             else
               echo "Skipping $file because it is empty."
             fi

--- a/.github/workflows/merge-libs-compile-circuitpython-files.yml
+++ b/.github/workflows/merge-libs-compile-circuitpython-files.yml
@@ -17,7 +17,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get -y install python3 python3-pip
 
       - name: Install Adafruit-ampy
-        run: python3 -m pip install adafruit-ampy
+        run: python3 -m pip install mpy-cross
 
       - name: JSON to variables
         uses: antifree/json-to-variables@v1.0.1
@@ -34,7 +34,7 @@ jobs:
             unzip -q sources_$key.zip -d sources_$key
             echo "$key successfully downloaded and extracted."
           done
-          
+
       - name: Merge libs
         run: |
           cp -r sources_dmcomm_python/*/lib/* lib/

--- a/.github/workflows/merge-libs-compile-circuitpython-files.yml
+++ b/.github/workflows/merge-libs-compile-circuitpython-files.yml
@@ -2,8 +2,9 @@ name: Merge libs and compile CircuitPython files
 
 on:
   push:
-    paths:
-      - '**/lib/**/*.py'
+  pull_request:
+  release:
+    types: [published]
 
 jobs:
   merge_and_compile:
@@ -68,7 +69,7 @@ jobs:
         with:
           name: wificom_libs_merged.zip
           path: .
-          
+
       - name: Attach to release
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/merge-libs-compile-circuitpython-files.yml
+++ b/.github/workflows/merge-libs-compile-circuitpython-files.yml
@@ -16,8 +16,8 @@ jobs:
       - name: Install required packages
         run: sudo apt-get update && sudo apt-get -y install python3 python3-pip
 
-      - name: Install build-mpy
-        run: python3 -m pip install build-mpy
+      - name: Install Adafruit-ampy
+        run: python3 -m pip install adafruit-ampy
 
       - name: Merge libs
         run: |
@@ -33,7 +33,7 @@ jobs:
         run: |
           for file in $(find ./lib -type f -name "*.py"); do
             echo "Compiling $file..."
-            python3 -m build_mpy --output-dir=./lib $file
+            mpy-cross $file
           done
 
       - name: Delete original .py files in lib/ folder

--- a/.github/workflows/merge-libs-compile-circuitpython-files.yml
+++ b/.github/workflows/merge-libs-compile-circuitpython-files.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Remove unnecessary files
         run: |
-          rm -rf sources_dmcomm_python sources_adafruit_bundle sources_circuitpython_minimqtt *.zip .git .github .gitignore .pylintrc
+          rm -rf sources_dmcomm_python sources_adafruit_bundle sources_circuitpython_minimqtt *.zip .git .github .gitignore .pylintrc mpy-cross.static-amd64-linux-8.0.0
   
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/merge-libs-compile-circuitpython-files.yml
+++ b/.github/workflows/merge-libs-compile-circuitpython-files.yml
@@ -68,6 +68,11 @@ jobs:
           echo "https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT" >> LICENSE.txt
           curl https://raw.githubusercontent.com/adafruit/Adafruit_CircuitPython_MiniMQTT/main/LICENSE >> LICENSE.txt
 
+      - uses: actions/upload-artifact@v2
+        with:
+          name: wificom_libs_merged.zip
+          path: .
+          
       - name: Create archive
         run: |
           rm -rf sources_dmcomm_python sources_adafruit_bundle sources_circuitpython_minimqtt *.zip
@@ -80,11 +85,6 @@ jobs:
           mv release.zip $filename
           echo "FILENAME=$filename" >> $GITHUB_ENV
         shell: /usr/bin/bash -e {0}
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: wificom_libs_merged.zip
-          path: .
 
       - name: Attach to release
         if: github.event_name == 'release'

--- a/.github/workflows/merge-libs-compile-circuitpython-files.yml
+++ b/.github/workflows/merge-libs-compile-circuitpython-files.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install required packages
         run: sudo apt-get update && sudo apt-get -y install python3 python3-pip
@@ -78,7 +78,7 @@ jobs:
             filename="wificom-lib_$GITHUB_SHA.zip"
           fi
           mv release.zip $filename
-          echo "::set-output name=filename::$filename"
+          echo "FILENAME=$filename" >> $GITHUB_ENV
         shell: /usr/bin/bash -e {0}
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/merge-libs-compile-circuitpython-files.yml
+++ b/.github/workflows/merge-libs-compile-circuitpython-files.yml
@@ -19,6 +19,22 @@ jobs:
       - name: Install Adafruit-ampy
         run: python3 -m pip install adafruit-ampy
 
+      - name: JSON to variables
+        uses: antifree/json-to-variables@v1.0.1
+        with:
+          filename: 'sources.json'
+          prefix: sources
+
+      - name: Download and extract sources
+        run: |
+          for key in dmcomm_python adafruit_bundle circuitpython_minimqtt; do
+            value=$(eval echo "\$sources_$key")
+            echo "Downloading and extracting $key..."
+            wget $value -O sources_$key.zip
+            unzip -q sources_$key.zip -d sources_$key
+            echo "$key successfully downloaded and extracted."
+          done
+          
       - name: Merge libs
         run: |
           cp -r sources_dmcomm_python/*/lib/* lib/

--- a/.github/workflows/merge-libs-compile-circuitpython-files.yml
+++ b/.github/workflows/merge-libs-compile-circuitpython-files.yml
@@ -68,14 +68,17 @@ jobs:
           echo "https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT" >> LICENSE.txt
           curl https://raw.githubusercontent.com/adafruit/Adafruit_CircuitPython_MiniMQTT/main/LICENSE >> LICENSE.txt
 
+      - name: Remove unnecessary files
+        run: |
+          rm -rf sources_dmcomm_python sources_adafruit_bundle sources_circuitpython_minimqtt *.zip
+  
       - uses: actions/upload-artifact@v2
         with:
           name: wificom_libs_merged.zip
           path: .
-          
+
       - name: Create archive
         run: |
-          rm -rf sources_dmcomm_python sources_adafruit_bundle sources_circuitpython_minimqtt *.zip
           zip -r release.zip *
           if [[ $GITHUB_REF =~ refs/tags/.* ]]; then
             filename="wificom-lib_$(echo $GITHUB_REF | awk -F/ '{print $3}').zip"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Sound on/off config option
+- GitHub Action to compile libraries into mpy files, removes all lib/**/*.py files that are not empty before archiving for release and artifacts
 ### Changed
 - Punchbag DigiROMs moved to `config.py` (`digiroms.py` removed)
 - Changed recommended `prong_in` on "Pi Pico + AirLift" from GP26 to GP22
 - Updated dmcomm-python to v0.5.0
+- Combined merge-libs-from-remote.yml GitHub Action into single file with mpy compilation
 
 ## [0.8.0] - 2023-02-15
 ### Added


### PR DESCRIPTION
- Compiles files in lib/ to mpy (wificom, dmcomm-python, the rest are already compiled)
- Skips compiling empty *.py files to save space
