### PR TITLE
MQTT Polling Retries & Reliability Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-### Added
-- Logic to detect MQTT failures and display error to reboot by holding button C if more than 10 failures occur
-- Logic to detect MQTT Publish failures
-### Tested with
-- CircuitPython 8.0.4
-- MiniMQTT 7.3.2
-
 ## [0.9.0] - 2023-02-27
 ### Added
 - Sound on/off config option

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Logic to detect MQTT failures and display error to reboot by holding button C if more than 10 failures occur
+- Logic to detect MQTT Publish failures
+### Tested with
+- CircuitPython 8.0.4
+- MiniMQTT 7.3.2
+
 ## [0.9.0] - 2023-02-27
 ### Added
 - Sound on/off config option

--- a/code.py
+++ b/code.py
@@ -258,17 +258,16 @@ def run_wifi():
 					break
 				time.sleep(0.1)
 
-failure_count = 0
-start_time = time.monotonic()
+mqtt_failure_count = 0
+mqtt_failure_start_time = time.monotonic()
 
 def mqtt_loop():
 	"""
 	Loop that calls mqtt.loop function with error handling and retries
 	"""
 	# pylint: disable=global-statement
-	global failure_count
-	global start_time
-	mqtt_loop_timeout = 120
+	global mqtt_failure_count
+	global mqtt_failure_start_time
 
 	loop_result = mqtt.loop()
 
@@ -277,18 +276,18 @@ def mqtt_loop():
 		pass
 	else:
 		# If the result is False, increment failure_count
-		failure_count += 1
-		print(f"Failure count: {failure_count}")
+		mqtt_failure_count += 1
+		print(f"Failure count: {mqtt_failure_count}")
 
-	if time.monotonic() - start_time <= mqtt_loop_timeout:
+	if time.monotonic() - mqtt_failure_start_time <= 30:
 		# Quit if 30 seconds have passed since the start time
-		if failure_count >= 10:
+		if mqtt_failure_count >= 10:
 			print("Maximum number of failures reached within 30 seconds. MQTT Failure...")
 			connection_failure_alert("MQTT")
 	else:
 		# Reset the failure count and start time if 30 seconds have passed
-		failure_count = 0
-		start_time = time.monotonic()
+		mqtt_failure_count = 0
+		mqtt_failure_start_time = time.monotonic()
 
 def connection_failure_alert(failure_type):
 	'''

--- a/code.py
+++ b/code.py
@@ -235,7 +235,9 @@ def run_wifi():
 			if time_start - rtb_last_ping > 10:
 				mqtt.send_digirom_output("RTB")
 				rtb_last_ping = time_start
-			mqtt.loop()
+			mqtt_connect = mqtt.loop()
+			if mqtt_connect is False:
+				connection_failure_alert("MQTT")
 			rtb.loop()
 		else:
 			if rtb_was_active:
@@ -251,7 +253,9 @@ def run_wifi():
 			mqtt.send_digirom_output(last_output)
 
 			while True:
-				mqtt.loop()
+				mqtt_connect = mqtt.loop()
+				if mqtt_connect is False:
+					connection_failure_alert("MQTT")
 				if mqtt.get_subscribed_output(False) is not None:
 					break
 				if time.monotonic() - time_start >= 5:

--- a/code.py
+++ b/code.py
@@ -258,7 +258,6 @@ def run_wifi():
 					break
 				time.sleep(0.1)
 
-mqtt_failure_count = 0
 mqtt_failure_start_time = time.monotonic()
 
 def mqtt_loop():
@@ -266,8 +265,8 @@ def mqtt_loop():
 	Loop that calls mqtt.loop function with error handling and retries
 	"""
 	# pylint: disable=global-statement
-	global mqtt_failure_count
 	global mqtt_failure_start_time
+	mqtt_failure_count = mqtt.get_failure_count()
 
 	loop_result = mqtt.loop()
 

--- a/lib/wificom/mqtt.py
+++ b/lib/wificom/mqtt.py
@@ -87,6 +87,7 @@ def loop():
 			if time.monotonic() - start_time >= timeout:
 				start_time = time.monotonic()
 				failure_count = 0
+				return True
 
 			if failure_count == max_failures:
 				print("Maximum number of failures reached.")

--- a/lib/wificom/mqtt.py
+++ b/lib/wificom/mqtt.py
@@ -67,10 +67,29 @@ def connect_to_mqtt(mqtt_client):
 	return True
 
 def loop():
-	'''
-	Loop IO MQTT client
-	'''
-	_mqtt_client.loop()
+    """
+    Loop IO MQTT client
+    """
+    max_failures = 5
+    failure_count = 0
+    start_time = time.monotonic()
+    timeout = 50
+
+    while failure_count < max_failures:
+        try:
+            _mqtt_client.loop()
+            return True
+        except Exception as e:
+            failure_count += 1
+            print(f"Error: {e}. Attempt {failure_count} of {max_failures} failed.")
+
+            if time.monotonic() - start_time >= timeout:
+                start_time = time.monotonic()
+                failure_count = 0 
+
+            if failure_count == max_failures:
+                print("Maximum number of failures reached.")
+                return False 
 
 def get_subscribed_output(clear_rom=True):
 	'''

--- a/lib/wificom/mqtt.py
+++ b/lib/wificom/mqtt.py
@@ -71,7 +71,7 @@ def loop():
 	Loop IO MQTT client
 	'''
 	try:
-		_mqtt_client.loop(timeout=2.0)
+		_mqtt_client.loop()
 		return True
 	# pylint: disable=broad-except
 	except Exception:
@@ -106,7 +106,11 @@ def send_digirom_output(output):
 	mqtt_message_json = json.dumps(mqtt_message)
 
 	if _mqtt_client.is_connected:
-		_mqtt_client.publish(_mqtt_topic_output, mqtt_message_json)
+		try:
+			_mqtt_client.publish(_mqtt_topic_output, mqtt_message_json)
+		#pylint: disable=broad-except
+		except Exception:
+			print("Failed to send MQTT message")
 
 def send_rtb_digirom_output(output):
 	'''

--- a/lib/wificom/mqtt.py
+++ b/lib/wificom/mqtt.py
@@ -67,32 +67,16 @@ def connect_to_mqtt(mqtt_client):
 	return True
 
 def loop():
-	"""
+	'''
 	Loop IO MQTT client
-	"""
-	max_failures = 5
-	failure_count = 0
-	start_time = time.monotonic()
-	timeout = 50
+	'''
+	try:
+		_mqtt_client.loop(timeout=2.0)
+		return True
+	# pylint: disable=broad-except
+	except Exception:
+		return False
 
-	while failure_count < max_failures:
-		try:
-			_mqtt_client.loop()
-			return True
-		# pylint: disable=broad-except
-		except Exception as e:
-			failure_count += 1
-			print(f"Error: {e}. Attempt {failure_count} of {max_failures} failed.")
-
-			if time.monotonic() - start_time >= timeout:
-				start_time = time.monotonic()
-				failure_count = 0
-				return True
-
-			if failure_count == max_failures:
-				print("Maximum number of failures reached.")
-				return False
-	return False
 def get_subscribed_output(clear_rom=True):
 	'''
 	Get the output from the MQTT broker, and load in new Digirom (and clear if clear_rom is True)

--- a/lib/wificom/mqtt.py
+++ b/lib/wificom/mqtt.py
@@ -92,7 +92,7 @@ def loop():
 			if failure_count == max_failures:
 				print("Maximum number of failures reached.")
 				return False
-
+	return False
 def get_subscribed_output(clear_rom=True):
 	'''
 	Get the output from the MQTT broker, and load in new Digirom (and clear if clear_rom is True)

--- a/lib/wificom/mqtt.py
+++ b/lib/wificom/mqtt.py
@@ -67,29 +67,30 @@ def connect_to_mqtt(mqtt_client):
 	return True
 
 def loop():
-    """
-    Loop IO MQTT client
-    """
-    max_failures = 5
-    failure_count = 0
-    start_time = time.monotonic()
-    timeout = 50
+	"""
+	Loop IO MQTT client
+	"""
+	max_failures = 5
+	failure_count = 0
+	start_time = time.monotonic()
+	timeout = 50
 
-    while failure_count < max_failures:
-        try:
-            _mqtt_client.loop()
-            return True
-        except Exception as e:
-            failure_count += 1
-            print(f"Error: {e}. Attempt {failure_count} of {max_failures} failed.")
+	while failure_count < max_failures:
+		try:
+			_mqtt_client.loop()
+			return True
+		# pylint: disable=broad-except
+		except Exception as e:
+			failure_count += 1
+			print(f"Error: {e}. Attempt {failure_count} of {max_failures} failed.")
 
-            if time.monotonic() - start_time >= timeout:
-                start_time = time.monotonic()
-                failure_count = 0 
+			if time.monotonic() - start_time >= timeout:
+				start_time = time.monotonic()
+				failure_count = 0
 
-            if failure_count == max_failures:
-                print("Maximum number of failures reached.")
-                return False 
+			if failure_count == max_failures:
+				print("Maximum number of failures reached.")
+				return False
 
 def get_subscribed_output(clear_rom=True):
 	'''

--- a/lib/wificom/mqtt.py
+++ b/lib/wificom/mqtt.py
@@ -73,8 +73,8 @@ def loop():
 	try:
 		_mqtt_client.loop()
 		return True
-	# pylint: disable=broad-except
-	except Exception:
+	except Exception as e: # pylint: disable=broad-except
+		print(f"Failed to connect to run MQTT loop: {repr(e)}")
 		return False
 
 def get_subscribed_output(clear_rom=True):
@@ -108,9 +108,8 @@ def send_digirom_output(output):
 	if _mqtt_client.is_connected:
 		try:
 			_mqtt_client.publish(_mqtt_topic_output, mqtt_message_json)
-		#pylint: disable=broad-except
-		except Exception:
-			print("Failed to send MQTT message")
+		except Exception as e: # pylint: disable=broad-except
+			print(f"Failed to connect to send MQTT publish message: {repr(e)}")  # pylint: disable=broad-except
 
 def send_rtb_digirom_output(output):
 	'''

--- a/lib/wificom/wifi_picow.py
+++ b/lib/wificom/wifi_picow.py
@@ -70,4 +70,3 @@ class Wifi:
 			)
 
 			return mqtt_client
-		return None

--- a/lib/wificom/wifi_picow.py
+++ b/lib/wificom/wifi_picow.py
@@ -64,8 +64,8 @@ class Wifi:
 				password=secrets_mqtt_password,
 				socket_pool=pool,
 				ssl_context=ssl.create_default_context(),
-				keep_alive=7,
-				recv_timeout=7,
+				keep_alive=5,
+				recv_timeout=5,
 				connect_retries=1,
 			)
 

--- a/lib/wificom/wifi_picow.py
+++ b/lib/wificom/wifi_picow.py
@@ -67,3 +67,4 @@ class Wifi:
 			)
 
 			return mqtt_client
+		return None

--- a/lib/wificom/wifi_picow.py
+++ b/lib/wificom/wifi_picow.py
@@ -64,6 +64,9 @@ class Wifi:
 				password=secrets_mqtt_password,
 				socket_pool=pool,
 				ssl_context=ssl.create_default_context(),
+				keep_alive=7,
+				recv_timeout=7,
+				connect_retries=1,
 			)
 
 			return mqtt_client

--- a/sources.json
+++ b/sources.json
@@ -1,5 +1,5 @@
 {
-    "dmcomm_python": "https://github.com/dmcomm/dmcomm-python/archive/refs/tags/v0.5.0.zip",
-    "adafruit_bundle": "https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/download/20221111/adafruit-circuitpython-bundle-8.x-mpy-20221111.zip",
-    "circuitpython_minimqtt": "https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/releases/download/5.5.1/adafruit-circuitpython-minimqtt-8.x-mpy-5.5.1.zip"
+  "dmcomm_python": "https://github.com/dmcomm/dmcomm-python/archive/refs/tags/v0.5.0.zip",
+  "adafruit_bundle": "https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/download/20221111/adafruit-circuitpython-bundle-8.x-mpy-20221111.zip",
+  "circuitpython_minimqtt": "https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/releases/download/7.3.2/adafruit-circuitpython-minimqtt-8.x-mpy-7.3.2.zip"
 }


### PR DESCRIPTION
**Description**
- Polls MQTT with up to 10 failures in 30 seconds before displaying the error page to go back and try again
  - This should now cleanly exit without an error message that requires a reboot on MQTT failures
  - I don't anticipate hitting 10, the failures seem to be intermittent and previously a failure for any reason would immediately crash the WiFiCom
  - Also in mqtt.send_digirom_output() we try/except the publish, later plans to add a max failure rate here too
- I reused the code for displaying failure via code.py, so the user can simply go back and try to connect again in the case of a failure

**Bugfixes**
- Pylint inconsistent-return-types fixed in code.py and picow.py

**TODO**
- [x] Test this by simulating a MQTT failure (bring down QA MQTT while connected and watch it fail gracefully)

## CHANGELOG
### ADDED
- MQTT polling retries so a failure doesn't occur immediately on the first intermittent issues, gives MQTT a chance to recover
   - On 10 failures in 30 seconds you will be kicked back to an error screen prompting to hold C to reboot (and can then try again)
   - mqtt.send_digirom_output() is also try/excepted now
 
### Tested with
- CircuitPython 8.0.4