### PR TITLE
GitHub Actions:  MiniMQTT Nina/PicoW Variants

### DIFF
--- a/.github/workflows/merge-libs-compile-circuitpython-files.yml
+++ b/.github/workflows/merge-libs-compile-circuitpython-files.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   merge_and_compile:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [nina, picow]
 
     steps:
       - uses: actions/checkout@v3
@@ -28,24 +31,35 @@ jobs:
           prefix: sources
 
       - name: Download and extract sources
+        env:
+          PLATFORM: ${{ matrix.platform }}
         run: |
-          for key in dmcomm_python adafruit_bundle circuitpython_minimqtt; do
+          for key in dmcomm_python adafruit_bundle; do
             value=$(eval echo "\$sources_$key")
             echo "Downloading and extracting $key..."
             wget $value -O sources_$key.zip
             unzip -q sources_$key.zip -d sources_$key
             echo "$key successfully downloaded and extracted."
           done
+          key="circuitpython_minimqtt"
+          value=$(eval echo "\$sources_${PLATFORM}_${key}")
+          echo "Platform: $PLATFORM"
+          echo "Downloading and extracting $key for $PLATFORM..."
+          wget $value -O sources_${PLATFORM}_${key}.zip
+          unzip -q sources_${PLATFORM}_${key}.zip -d sources_${PLATFORM}_${key}
+          echo "$key for $PLATFORM successfully downloaded and extracted."
 
       - name: Merge libs
+        env:
+          PLATFORM: ${{ matrix.platform }}
         run: |
           cp -r sources_dmcomm_python/*/lib/* lib/
           cp -r sources_adafruit_bundle/*/lib/adafruit_bus_device lib/
           cp -r sources_adafruit_bundle/*/lib/adafruit_display_text lib/
           cp -r sources_adafruit_bundle/*/lib/adafruit_displayio_ssd1306.mpy lib/
           cp -r sources_adafruit_bundle/*/lib/adafruit_requests.mpy lib/
-          cp -r sources_adafruit_bundle/*/lib/adafruit_esp32spi   lib/
-          cp -r sources_circuitpython_minimqtt/*/lib/* lib/
+          cp -r sources_adafruit_bundle/*/lib/adafruit_esp32spi lib/
+          cp -r sources_${PLATFORM}_circuitpython_minimqtt/*/lib/* lib/
 
       - name: Compile CircuitPython files to .mpy files
         run: |
@@ -83,20 +97,22 @@ jobs:
 
       - name: Remove unnecessary files
         run: |
-          rm -rf sources_dmcomm_python sources_adafruit_bundle sources_circuitpython_minimqtt *.zip .git .github .gitignore .pylintrc mpy-cross.static-amd64-linux-8.0.0
+          rm -rf sources_dmcomm_python sources_adafruit_bundle sources_nina_circuitpython_minimqtt sources_picow_circuitpython_minimqtt *.zip .git .github .gitignore .pylintrc mpy-cross.static-amd64-linux-8.0.0
   
       - uses: actions/upload-artifact@v2
         with:
-          name: wificom_libs_merged.zip
+          name: wificom_libs_merged_${{ matrix.platform }}.zip
           path: .
 
       - name: Create archive
+        env:
+          PLATFORM: ${{ matrix.platform }}
         run: |
           zip -r release.zip *
           if [[ $GITHUB_REF =~ refs/tags/.* ]]; then
-            filename="wificom-lib_$(echo $GITHUB_REF | awk -F/ '{print $3}').zip"
+            filename="wificom-lib_$(echo $GITHUB_REF | awk -F/ '{print $3}')_${PLATFORM}.zip"
           else
-            filename="wificom-lib_$GITHUB_SHA.zip"
+            filename="wificom-lib_${GITHUB_SHA}_${PLATFORM}.zip"
           fi
           mv release.zip $filename
           echo "FILENAME=$filename" >> $GITHUB_ENV

--- a/.github/workflows/merge-libs-compile-circuitpython-files.yml
+++ b/.github/workflows/merge-libs-compile-circuitpython-files.yml
@@ -42,7 +42,7 @@ jobs:
             echo "$key successfully downloaded and extracted."
           done
           key="circuitpython_minimqtt"
-          value=$(eval echo "\$sources_${PLATFORM}_${key}")
+          value=$(eval echo "\$sources_${key}_${PLATFORM}")
           echo "Platform: $PLATFORM"
           echo "Downloading and extracting $key for $PLATFORM..."
           wget $value -O sources_${PLATFORM}_${key}.zip

--- a/lib/wificom/wifi_picow.py
+++ b/lib/wificom/wifi_picow.py
@@ -66,5 +66,4 @@ class Wifi:
 				ssl_context=ssl.create_default_context(),
 			)
 
-
 			return mqtt_client

--- a/lib/wificom/wifi_picow.py
+++ b/lib/wificom/wifi_picow.py
@@ -66,4 +66,4 @@ class Wifi:
 				ssl_context=ssl.create_default_context(),
 			)
 
-			return mqtt_client
+		return mqtt_client

--- a/lib/wificom/wifi_picow.py
+++ b/lib/wificom/wifi_picow.py
@@ -66,4 +66,5 @@ class Wifi:
 				ssl_context=ssl.create_default_context(),
 			)
 
-		return mqtt_client
+
+			return mqtt_client

--- a/sources.json
+++ b/sources.json
@@ -1,5 +1,8 @@
 {
     "dmcomm_python": "https://github.com/dmcomm/dmcomm-python/archive/refs/tags/v0.5.0.zip",
     "adafruit_bundle": "https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/download/20221111/adafruit-circuitpython-bundle-8.x-mpy-20221111.zip",
-    "circuitpython_minimqtt": "https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/releases/download/5.5.1/adafruit-circuitpython-minimqtt-8.x-mpy-5.5.1.zip"
-}
+    "circuitpython_minimqtt": {
+        "nina": "https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/releases/download/5.5.1/adafruit-circuitpython-minimqtt-8.x-mpy-5.5.1.zip",
+        "picow": "https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/releases/download/7.3.2/adafruit-circuitpython-minimqtt-8.x-mpy-7.3.2.zip"
+        }
+    } 


### PR DESCRIPTION
**Description**
I was testing CircuitPython 8.0.4 and found 5.5.1 of MiniMQTT to be incompatible on PicoW but compatible on Nina (running CircuitPython 8.0.4).  I also found out that the latest version of MIniMQTT is very fast in comparison to 5.5.1 (7.3.2).  The connection takes milliseconds on 7.3.2 MiniMQTT instead of seconds.

As a result of my findings I decided to update the GitHub Action to include a matrix for builds for both platforms.  With these builds we can safely go up to CircuitPython 8.0.4 without issues and with the same codebase.

See Artifacts on the last successful build for an example:
![image](https://user-images.githubusercontent.com/7636463/226097515-3b98759b-ea10-49c5-8aca-67cd310e32f2.png)

## CHANGELOG
### ADDED
- Separate builds for nina and picow microcontrollers with the ability to use variants for MIniMQTT dependency. Will show up as two archives, one endeing in _nina.zip and other in _picow.zip for both artifacts and release attached bundles.
