### PR TITLE
Lock pylint to v2.16.2 in Github Action

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pylint
+        pip install pylint==2.16.2
     - name: Analysing the code with pylint
       run: |
         pylint $(git ls-files '*.py')


### PR DESCRIPTION
**Description**

Lock pylint to v2.16.2 to maintain compatibility with our existing defined linting rules.

**CHANGELOG**
### EDITED
- Pylint now locked to v2.16.2 when processed by GItHub Actions