### PR TITLE
Make serial line ending CRLF to match Arduino

### DIFF
--- a/lib/wificom/main.py
+++ b/lib/wificom/main.py
@@ -35,7 +35,7 @@ if usb_cdc.data is not None:
 else:
 	serial = usb_cdc.console
 
-def serial_print(contents, end="\n"):
+def serial_print(contents, end="\r\n"):
 	'''
 	Print output to the serial console
 	'''


### PR DESCRIPTION
Unlike dmcomm-python it only appears in `serial_print`, so just changed it there.

## Changelog
### Changed
- For messages which can appear in serial mode, changed ending of output lines from "\n" to "\r\n" to match Arduino
