### PR TITLE
Disable auto-reload when not in dev mode

### DIFF
--- a/lib/wificom/main.py
+++ b/lib/wificom/main.py
@@ -379,6 +379,8 @@ def main(led_pwm):
 		serial_print("request cleared")
 	else:
 		serial_print("not requested")
+	if startup_mode != nvm.MODE_DEV:
+		supervisor.runtime.autoreload = False
 
 	displayio.release_displays()
 	ui = wificom.ui.UserInterface(**board_config.ui_pins)


### PR DESCRIPTION
Originally I called this "Disable auto-reload in drive mode", but since all other modes have CIRCUITPY read-only, this way is simpler.

## Changelog
### Changed
- Disabled auto-reload on CIRCUITPY change, except in dev mode