### PR TITLE
Log crash tracebacks to file

### DIFF
--- a/lib/wificom/main.py
+++ b/lib/wificom/main.py
@@ -339,7 +339,7 @@ def run_drive():
 	)
 	result()
 
-def failure_alert(message):
+def failure_alert(message, hard_reset=False):
 	'''
 	Alert on failure and allow restart.
 	'''
@@ -350,7 +350,10 @@ def failure_alert(message):
 		time.sleep(0.5)
 		if ui.is_c_pressed():
 			time.sleep(2)
-			supervisor.reload()
+			if hard_reset:
+				microcontroller.reset()
+			else:
+				supervisor.reload()
 
 def rotate_log():
 	'''
@@ -383,10 +386,12 @@ def report_crash(crash_exception):
 			f.write(f"Crash ID {random_number}:\r\n{trace}\r\n")
 		serial_print("Wrote log")
 		message += f"(log#{random_number})"
+		hard_reset = True
 	except OSError as e:
 		serial_print("Cannot write log: " + repr(e))
 		message += "(log failed)"
-	failure_alert(message)
+		hard_reset = False
+	failure_alert(message, hard_reset)
 
 def main(led_pwm):
 	'''

--- a/lib/wificom/main.py
+++ b/lib/wificom/main.py
@@ -6,6 +6,7 @@ Handles WiFiCom main program logic.
 import time
 import gc
 import os
+import random
 import traceback
 
 import digitalio
@@ -376,11 +377,12 @@ def report_crash(crash_exception):
 	trace = "".join(traceback.format_exception(crash_exception))
 	serial_print(trace)
 	message = "Crashed "
+	random_number = random.randint(100, 999)
 	try:
 		with open(LOG_FILENAME, "a", encoding="utf-8") as f:
-			f.write(trace + "\r\n")
+			f.write(f"Crash ID {random_number}:\r\n{trace}\r\n")
 		serial_print("Wrote log")
-		message += "(see log)"
+		message += f"(log#{random_number})"
 	except OSError as e:
 		serial_print("Cannot write log: " + repr(e))
 		message += "(log failed)"

--- a/lib/wificom/main.py
+++ b/lib/wificom/main.py
@@ -165,7 +165,6 @@ def menu_reboot(mode):
 	nvm.set_mode(mode)
 	ui.display_text("Rebooting...")
 	time.sleep(0.5)
-	ui.clear()
 	microcontroller.reset()
 
 def run_wifi():
@@ -344,16 +343,16 @@ def failure_alert(message, hard_reset=False):
 	Alert on failure and allow restart.
 	'''
 	led.duty_cycle = 0
-	ui.display_text(f"{message}\nHold C to reboot")
+	ui.display_text(f"{message}\nPress A to reboot")
 	ui.beep_failure()
-	while True:
-		time.sleep(0.5)
-		if ui.is_c_pressed():
-			time.sleep(2)
-			if hard_reset:
-				microcontroller.reset()
-			else:
-				supervisor.reload()
+	while not ui.is_a_pressed():
+		pass
+	ui.display_text("Rebooting...")
+	time.sleep(0.5)
+	if hard_reset:
+		microcontroller.reset()
+	else:
+		supervisor.reload()
 
 def rotate_log():
 	'''

--- a/lib/wificom/ui.py
+++ b/lib/wificom/ui.py
@@ -150,9 +150,9 @@ class UserInterface:
 		'''
 		f = self.audio_base_freq
 		self._speaker.play([(f, 0.15), (f/2, 0.15)])
-	def beep_wifi_failure(self):
+	def beep_failure(self):
 		'''
-		Beep for WiFi connection failure.
+		Beep to indicate failure (blocking).
 		'''
 		for _ in range(3):
 			self.beep_error()


### PR DESCRIPTION
### Added
- Unexpected exceptions are caught and tracebacks logged to `wificom_log.txt` in CIRCUITPY. File rotated to `wificom_log_old.txt` according to size. Reboot made easier after a crash.
### Changed
- Reboot after failure waits for short A press instead of holding C.