### PR TITLE
Add screenless button use + failure LED blink

### DIFF
--- a/lib/wificom/import_secrets.py
+++ b/lib/wificom/import_secrets.py
@@ -10,6 +10,7 @@ secrets_mqtt_broker = ""
 secrets_mqtt_username = ""
 secrets_mqtt_password = ""
 secrets_imported = False
+secrets_error = ""
 secrets_error_display = ""
 
 try:
@@ -31,15 +32,14 @@ try:
 	secrets_imported = True
 
 except ImportError:
-	print("secrets.py is missing, please copy and edit from webapp or secrets.example.py")
+	secrets_error = "secrets.py is missing, please copy and edit from webapp or secrets.example.py"
 	secrets_error_display = "secrets.py missing"
 except SyntaxError:
-	print("Syntax error in secrets.py")
-	secrets_error_display = "secrets.py\nSyntaxError"
-except TypeError:
-	print("Error in wireless_networks in secrets.py")
-	secrets_error_display = "secrets.py\nNetworks layout"
+	secrets_error = "Syntax error in secrets.py"
+	secrets_error_display = "secrets.py syntax"
+except TypeError as e:
+	secrets_error = "Error in wireless_networks in secrets.py: " + str(e)
+	secrets_error_display = "secrets.py networks"
 except KeyError as e:
-	print("Missing field in secrets.py")
-	print(e)
-	secrets_error_display = "secrets.py\nKeyError: " + str(e)
+	secrets_error = "Missing field in secrets.py: " + str(e)
+	secrets_error_display = "secrets " + str(e)

--- a/lib/wificom/main.py
+++ b/lib/wificom/main.py
@@ -211,8 +211,7 @@ def run_wifi():
 	if done_wifi_before:
 		if startup_mode == nvm.MODE_DEV:
 			ui.display_text("Soft reboot...")
-			time.sleep(0.5)
-			ui.clear()
+			time.sleep(0.8)
 			supervisor.reload()
 		else:
 			menu_reboot(nvm.MODE_WIFI)
@@ -365,13 +364,20 @@ def failure_alert(message, hard_reset=False):
 	led.duty_cycle = 0
 	ui.display_text(f"{message}\nPress A to reboot")
 	ui.beep_failure()
-	while not ui.is_a_pressed():
-		pass
-	ui.display_text("Rebooting...")
-	time.sleep(0.5)
+	while not ui.is_a_pressed(True):
+		# Short blink every 2s
+		if int(time.monotonic() * 10) % 20 == 0:
+			led.duty_cycle = 0xFFFF
+		else:
+			led.duty_cycle = 0
+	led.duty_cycle = 0
 	if hard_reset:
+		ui.display_text("Rebooting...")
+		time.sleep(0.5)
 		microcontroller.reset()
 	else:
+		ui.display_text("Soft reboot...")
+		time.sleep(0.8)
 		supervisor.reload()
 
 def rotate_log():

--- a/lib/wificom/main.py
+++ b/lib/wificom/main.py
@@ -22,7 +22,7 @@ import wificom.realtime as rt
 import wificom.ui
 from wificom import nvm
 from wificom import mqtt
-from wificom.import_secrets import secrets_imported, secrets_error_display
+from wificom.import_secrets import secrets_imported, secrets_error, secrets_error_display
 from config import config
 import board_config
 
@@ -201,11 +201,8 @@ def run_wifi():
 	rtb_last_ping = 0
 
 	if not secrets_imported:
-		print("Error with secrets.py (see above)")
-		ui.display_text(secrets_error_display)
-		while not ui.is_c_pressed():
-			pass
-		return
+		print(secrets_error)
+		failure_alert(secrets_error_display)
 
 	global done_wifi_before  # pylint: disable=global-statement
 	if done_wifi_before:

--- a/lib/wificom/main.py
+++ b/lib/wificom/main.py
@@ -405,6 +405,7 @@ def report_crash(crash_exception):
 	trace = "".join(traceback.format_exception(crash_exception))
 	serial_print(trace)
 	message = "Crashed "
+	rotate_log()
 	random_number = random.randint(100, 999)
 	try:
 		with open(LOG_FILENAME, "a", encoding="utf-8") as f:
@@ -459,7 +460,6 @@ def main(led_pwm):
 	ui = wificom.ui.UserInterface(**board_config.ui_pins)
 	ui.sound_on = config["sound_on"]
 	led = led_pwm
-	rotate_log()
 
 	run_column = 0
 	if not ui.has_display:

--- a/lib/wificom/main.py
+++ b/lib/wificom/main.py
@@ -369,6 +369,7 @@ def failure_alert(message, hard_reset=False):
 		else:
 			led.duty_cycle = 0
 	led.duty_cycle = 0
+	ui.beep_activate()
 	if hard_reset:
 		ui.display_text("Rebooting...")
 		time.sleep(0.5)

--- a/lib/wificom/ui.py
+++ b/lib/wificom/ui.py
@@ -54,11 +54,11 @@ class UserInterface:
 			for button_id in "ABC":
 				self._buttons[button_id].pull = digitalio.Pull.UP
 		else:
-			# Physical button C takes the B role
-			self._buttons["B"] = digitalio.DigitalInOut(button_c)
-			self._buttons["B"].pull = digitalio.Pull.UP
-			self._buttons["A"] = None
-			self._buttons["C"] = None
+			# Physical button C can be any button in specified cases
+			self._buttons["C"] = digitalio.DigitalInOut(button_c)
+			self._buttons["C"].pull = digitalio.Pull.UP
+			self._buttons["A"] = self._buttons["C"]
+			self._buttons["B"] = self._buttons["C"]
 		self._speaker = PIOSound(speaker)
 		self.sound_on = True
 		self.audio_base_freq = 1000
@@ -106,26 +106,26 @@ class UserInterface:
 			return
 		group = displayio.Group()
 		self._display.show(group)
-	def _is_button_pressed(self, button_id):
+	def _is_button_pressed(self, button_id, do_no_display):
 		button = self._buttons[button_id]
-		if button is None:
+		if self._display is None and not do_no_display:
 			return False
 		return not button.value
-	def is_a_pressed(self):
+	def is_a_pressed(self, do_no_display=False):
 		'''
 		Check if button A is pressed.
 		'''
-		return self._is_button_pressed("A")
-	def is_b_pressed(self):
+		return self._is_button_pressed("A", do_no_display)
+	def is_b_pressed(self, do_no_display=False):
 		'''
 		Check if button B is pressed.
 		'''
-		return self._is_button_pressed("B")
-	def is_c_pressed(self):
+		return self._is_button_pressed("B", do_no_display)
+	def is_c_pressed(self, do_no_display=False):
 		'''
 		Check if button C is pressed.
 		'''
-		return self._is_button_pressed("C")
+		return self._is_button_pressed("C", do_no_display)
 	def beep_normal(self):
 		'''
 		A normal beep.


### PR DESCRIPTION
### Added
- Short LED blink every 2 seconds when failure is reported
- Screenless units can reboot by pressing the button when failure is reported
- Beep on press-to-reboot after failure
### Changed
- Use failure alert feature for secrets.py errors
- Rotate crash log before writing it to avoid having only "_old" (don't need to mention in final changelog)