### PR TITLE
Allow non-WiFi

### DIFF
--- a/board_config.py
+++ b/board_config.py
@@ -13,6 +13,8 @@ Non-WiFi:
 Recommended pins are assigned here for:
 - Raspberry Pi Pico
 - Seeeduino Xiao RP2040
+
+Note `wifi_type` is not present in older board_config.
 '''
 
 import board
@@ -108,6 +110,10 @@ else:
 	raise ValueError("Please configure pins in board_config.py")
 
 # pylint: disable=unused-import
+try:
+	import wificom
+except ImportError:
+	wifi_type = None  # support dmcomm-python by itself
 if wifi_type == "picow":
 	from wificom.wifi_picow import Wifi as WifiCls
 elif wifi_type == "nina":

--- a/board_config.py
+++ b/board_config.py
@@ -82,7 +82,9 @@ elif board.board_id == "arduino_nano_rp2040_connect":
 	}
 elif board.board_id == "seeeduino_xiao_rp2040":
 	wifi_type = None
-	led_pin = board.LED
+	# This LED is inverted, so pretty useless.
+	# Fortunately not really needed on a non-WiFi board.
+	led_pin = board.LED_GREEN
 	controller_pins = [
 		hw.ProngOutput(board.D10, board.D7),  # D10 is GP3, D9 is GP4
 		hw.ProngInput(board.D8),
@@ -98,7 +100,9 @@ elif board.board_id == "seeeduino_xiao_rp2040":
 		"button_a": None,
 		"button_b": None,
 		"button_c": board.D6,
-		"speaker": board.D5,
+		# Speaker is not currently optional.
+		# Avoid wasting a pin we might need in future. You don't really notice this.
+		"speaker": board.LED_RED,
 	}
 else:
 	raise ValueError("Please configure pins in board_config.py")

--- a/board_config.py
+++ b/board_config.py
@@ -2,24 +2,52 @@
 board_config.py
 Handles differences between boards.
 
-Pi Pico W, with BladeSabre's pin assignments. RECOMMENDED.
+WiFiCom:
+Recommended pins are assigned here for:
+- Raspberry Pi Pico W
+- Arduino Nano RP2040 Connect
+If you are using another RP2040 board with an AirLift module,
+you will need to edit this file.
 
-Arduino Nano RP2040 Connect, with BladeSabre's pin assignments.
-
-Pi Pico + AirLift, with BladeSabre's pin assignments.
-This was used for development but is no longer recommended.
-Screen is not included due to lack of pins.
-
+Non-WiFi:
+Recommended pins are assigned here for:
+- Raspberry Pi Pico
+- Seeeduino Xiao RP2040
 '''
+
 import board
 import dmcomm.hardware as hw
 
-print("Board ID: ", board.board_id)
-
-# pylint: disable=unused-import
-
-if board.board_id == "arduino_nano_rp2040_connect":
-	from wificom.wifi_nina import Wifi as WifiCls
+if board.board_id in ["raspberry_pi_pico", "raspberry_pi_pico_w"]:
+	if board.board_id == "raspberry_pi_pico_w":
+		wifi_type = "picow"
+		led_pin = board.GP10
+	else:
+		wifi_type = None
+		led_pin = board.LED
+	controller_pins = [
+		hw.ProngOutput(board.GP19, board.GP21),
+		hw.ProngInput(board.GP22),  # note this may need changed to GP26 on older builds
+		hw.InfraredOutput(board.GP16),
+		hw.InfraredInputModulated(board.GP17),
+		hw.InfraredInputRaw(board.GP14),
+		hw.TalisInputOutput(board.GP15),
+	]
+	extra_power_pins = [
+		(board.GP13, True),
+		(board.GP18, True),
+	]
+	wifi_pins = {}
+	ui_pins = {
+		"display_scl": board.GP5,
+		"display_sda": board.GP4,
+		"button_a": board.GP9,
+		"button_b": board.GP8,
+		"button_c": board.GP3,
+		"speaker": board.GP2,
+	}
+elif board.board_id == "arduino_nano_rp2040_connect":
+	wifi_type = "nina"
 	led_pin = board.LED
 	controller_pins = [
 		hw.ProngOutput(board.A0, board.A2),
@@ -52,64 +80,33 @@ if board.board_id == "arduino_nano_rp2040_connect":
 		"button_c": board.D3,
 		"speaker": board.D0,
 	}
-elif board.board_id == "raspberry_pi_pico":
-	from wificom.wifi_nina import Wifi as WifiCls
+elif board.board_id == "seeeduino_xiao_rp2040":
+	wifi_type = None
 	led_pin = board.LED
 	controller_pins = [
-		hw.ProngOutput(board.GP19, board.GP21),
-		hw.ProngInput(board.GP22), #note this may need changed to GP26 on older builds
-		hw.InfraredOutput(board.GP16),
-		hw.InfraredInputModulated(board.GP17),
-		hw.InfraredInputRaw(board.GP14),
-		hw.TalisInputOutput(board.GP15),
+		hw.ProngOutput(board.D10, board.D7),  # D10 is GP3, D9 is GP4
+		hw.ProngInput(board.D8),
+		hw.InfraredOutput(board.A1),
+		hw.InfraredInputModulated(board.A2),
+		hw.InfraredInputRaw(board.A0),
 	]
-	extra_power_pins = [
-		(board.GP13, True),
-		(board.GP18, True),
-	]
-	wifi_pins = {
-		"esp32_sck": board.GP6,
-		"esp32_mosi": board.GP7,
-		"esp32_miso": board.GP4,
-		"esp32_cs": board.GP5,
-		"esp32_busy": board.GP8,
-		"esp32_reset": board.GP9,
-	}
+	extra_power_pins = []
+	wifi_pins = {}
 	ui_pins = {
 		"display_scl": None,
 		"display_sda": None,
 		"button_a": None,
 		"button_b": None,
-		"button_c": board.GP3,
-		"speaker": board.GP11,
-	}
-	# GP0-2 for flashing AirLift (not included in this software):
-	# GP0 TX to AirLift RX
-	# GP1 RX to AirLift TX
-	# GP2 to AirLift GP0
-elif board.board_id == "raspberry_pi_pico_w":
-	from wificom.wifi_picow import Wifi as WifiCls
-	led_pin = board.GP10
-	controller_pins = [
-		hw.ProngOutput(board.GP19, board.GP21),
-		hw.ProngInput(board.GP22),
-		hw.InfraredOutput(board.GP16),
-		hw.InfraredInputModulated(board.GP17),
-		hw.InfraredInputRaw(board.GP14),
-		hw.TalisInputOutput(board.GP15),
-	]
-	extra_power_pins = [
-		(board.GP13, True),
-		(board.GP18, True),
-	]
-	wifi_pins = {}
-	ui_pins = {
-		"display_scl": board.GP5,
-		"display_sda": board.GP4,
-		"button_a": board.GP9,
-		"button_b": board.GP8,
-		"button_c": board.GP3,
-		"speaker": board.GP2,
+		"button_c": board.D6,
+		"speaker": board.D5,
 	}
 else:
-	raise ValueError("Your board is not supported.")
+	raise ValueError("Please configure pins in board_config.py")
+
+# pylint: disable=unused-import
+if wifi_type == "picow":
+	from wificom.wifi_picow import Wifi as WifiCls
+elif wifi_type == "nina":
+	from wificom.wifi_nina import Wifi as WifiCls
+else:
+	WifiCls = None  # pylint: disable=invalid-name

--- a/boot.py
+++ b/boot.py
@@ -15,16 +15,13 @@ BUTTON_NOT_PRESSED = 0
 BUTTON_RELEASED = 1
 BUTTON_HELD = 2
 
-STATE_NORMAL = 0
-STATE_DRIVE = 1
-STATE_SERIAL = 2
-
 supervisor.status_bar.console = False
 supervisor.status_bar.display = False
 usb_hid.disable()
 
 button_pin = board_config.ui_pins["button_c"]
 led_pin = board_config.led_pin
+has_wifi = board_config.WifiCls is not None
 
 if button_pin is not None:
 	led = digitalio.DigitalInOut(led_pin)
@@ -47,30 +44,25 @@ if button_pin is not None:
 				break
 		led.value = False
 
-	# button not pressed: WiFiCom with defaults or menu selection
-	# button released when LED came on: WiFiCom dev mode
-	# button held until LED went off: serial-only without drive or console
+	# Button not pressed: default / as requested
+	# Button released when LED came on: Dev Mode
+	# Button held until LED went off: Serial Mode (WiFiCom) / Dev Mode (P-Com)
+	drive_enabled = False
 	if button_result == BUTTON_NOT_PRESSED:
 		mode = nvm.get_mode()
-		if mode in [nvm.MODE_MENU, nvm.MODE_WIFI, nvm.MODE_PUNCHBAG]:
-			state = STATE_NORMAL
-		elif mode == nvm.MODE_SERIAL:
-			state = STATE_SERIAL
-		elif mode == nvm.MODE_DRIVE:
-			state = STATE_DRIVE
-		elif mode == nvm.MODE_DEV:
+		if mode == nvm.MODE_DRIVE and nvm.was_requested():
+			drive_enabled = True
+		elif mode in (nvm.MODE_DEV, nvm.MODE_DRIVE):
 			# this was not requested from software so reset it
 			nvm.set_mode(nvm.MODE_MENU)
-			state = STATE_NORMAL
-	elif button_result == BUTTON_RELEASED:
-		nvm.set_mode(nvm.MODE_DEV)
-		state = STATE_DRIVE
-	elif button_result == BUTTON_HELD:
+	elif has_wifi and button_result == BUTTON_HELD:
 		nvm.set_mode(nvm.MODE_SERIAL)
-		state = STATE_SERIAL
+	elif button_result in (BUTTON_RELEASED, BUTTON_HELD):
+		nvm.set_mode(nvm.MODE_DEV)
+		drive_enabled = True
 
 	print("Mode:", nvm.get_mode_str())
-	if state == STATE_DRIVE:
+	if drive_enabled:
 		print("CIRCUITPY drive is writeable")
 	else:
 		storage.remount("/", False)

--- a/boot.py
+++ b/boot.py
@@ -60,8 +60,8 @@ if button_pin is not None:
 	elif button_result in (BUTTON_RELEASED, BUTTON_HELD):
 		nvm.set_mode(nvm.MODE_DEV)
 		drive_enabled = True
-
 	print("Mode:", nvm.get_mode_str())
+	print("WiFi:", "enabled" if has_wifi else "disabled")
 	if drive_enabled:
 		print("CIRCUITPY drive is writeable")
 	else:

--- a/lib/wificom/main.py
+++ b/lib/wificom/main.py
@@ -147,22 +147,24 @@ def main_menu(play_startup_sound=True):
 	serial_print("Main menu")
 	if play_startup_sound:
 		ui.beep_ready()
+	options = []
+	results = []
 	if startup_mode == nvm.MODE_DEV:
-		options_prefix = ["* Dev Mode *"]
-		results_prefix = [None]
-		options_suffix = []
-		results_suffix = []
-	else:
-		options_prefix = []
-		results_prefix = []
-		options_suffix = ["Drive"]
-		results_suffix = [menu_drive]
+		options.append("* Dev Mode *")
+		results.append(None)
+	if startup_mode == nvm.MODE_DRIVE:
+		options.append("* Drive Mode *")
+		results.append(None)
+	if board_config.WifiCls is not None:
+		options.append("WiFi")
+		results.append(menu_wifi)
+	options.extend(["Serial", "Punchbag"])
+	results.extend([menu_serial, menu_punchbag])
+	if startup_mode not in (nvm.MODE_DEV, nvm.MODE_DRIVE):
+		options.append("Drive")
+		results.append(menu_drive)
 	while True:
-		menu_result = ui.menu(
-			options_prefix + ["WiFi", "Serial", "Punchbag"] + options_suffix,
-			results_prefix + [menu_wifi, menu_serial, menu_punchbag] + results_suffix,
-			None,
-		)
+		menu_result = ui.menu(options, results, None)
 		menu_result()
 
 def menu_wifi():
@@ -219,6 +221,12 @@ def run_wifi():
 	Do the normal WiFiCom things.
 	'''
 	# pylint: disable=too-many-branches,too-many-statements
+
+	if board_config.WifiCls is None:
+		print("No WiFi specified in board_config; running serial")
+		menu_serial()
+		return
+
 	serial_print("Running WiFi")
 	gc.collect()
 	print("Free memory before WiFi:", gc.mem_free())
@@ -373,12 +381,7 @@ def run_drive():
 	if not ui.has_display:
 		while True:
 			pass
-	result = ui.menu(
-		["* Drive Mode *", "WiFi", "Serial", "Punchbag"],
-		[None, menu_wifi, menu_serial, menu_punchbag],
-		None,
-	)
-	result()
+	main_menu()
 
 def failure_alert(message, hard_reset=False):
 	'''


### PR DESCRIPTION
### Added
- Support for non-WiFi boards (with board_config entries for Pico and Xiao P-Coms) - button held on startup enters Dev Mode
### Changed
- Drive Mode no longer remembered when unplugged
### Removed
- board_config entry for Pico WiFiCom with AirLift

### Notes
Rewrote board_config. Old board_config still works. Boards are allowed to not have WiFi. Refactored menu code. So far, tested PicoW with old board_config, new board_config, and setting WifiCls to None. Need to test more boards, more toys, screenless, and dmcomm-python with this board_config. I didn't really want to add a speaker pin to the Xiao, but making that optional would be a major change and create additional testing burden.