### PR TITLE
Match mpy-cross to CircuitPython version

### DIFF
--- a/.github/workflows/merge-libs-compile-circuitpython-files.yml
+++ b/.github/workflows/merge-libs-compile-circuitpython-files.yml
@@ -27,16 +27,18 @@ jobs:
       - name: Install required packages
         run: sudo apt-get update && sudo apt-get -y install python3 python3-pip
 
-      - name: Download mpy-cross
-        run: |
-          wget https://adafruit-circuit-python.s3.amazonaws.com/bin/mpy-cross/mpy-cross.static-amd64-linux-8.0.0
-          chmod +x mpy-cross.static-amd64-linux-8.0.0
-
       - name: JSON to variables
         uses: antifree/json-to-variables@v1.0.1
         with:
           filename: 'sources.json'
           prefix: sources
+
+      - name: Download mpy-cross
+        run: |
+          ver=$(eval echo "\$sources_circuitpython_${PLATFORM}")
+          echo "CircuitPython version: $ver"
+          curl https://adafruit-circuit-python.s3.amazonaws.com/bin/mpy-cross/linux-amd64/mpy-cross-linux-amd64-{ver}.static > mpy-cross
+          chmod +x mpy-cross
 
       - name: Download and extract sources
         env:
@@ -74,7 +76,7 @@ jobs:
           for file in $(find ./lib -type f -name "*.py"); do
             if [ -s $file ]; then
               echo "Compiling $file..."
-              ./mpy-cross.static-amd64-linux-8.0.0 $file
+              ./mpy-cross $file
             else
               echo "Skipping $file because it is empty."
             fi
@@ -105,7 +107,7 @@ jobs:
 
       - name: Remove unnecessary files
         run: |
-          rm -rf sources_dmcomm_python sources_adafruit_bundle sources_nina_circuitpython_minimqtt sources_picow_circuitpython_minimqtt *.zip .git .github .gitignore .pylintrc mpy-cross.static-amd64-linux-8.0.0
+          rm -rf sources_dmcomm_python sources_adafruit_bundle sources_nina_circuitpython_minimqtt sources_picow_circuitpython_minimqtt *.zip .git .github .gitignore .pylintrc mpy-cross
   
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/merge-libs-compile-circuitpython-files.yml
+++ b/.github/workflows/merge-libs-compile-circuitpython-files.yml
@@ -36,8 +36,8 @@ jobs:
       - name: Download mpy-cross
         run: |
           ver=$(eval echo "\$sources_circuitpython_${PLATFORM}")
-          echo "CircuitPython version: $ver"
-          curl https://adafruit-circuit-python.s3.amazonaws.com/bin/mpy-cross/linux-amd64/mpy-cross-linux-amd64-{ver}.static > mpy-cross
+          echo "CircuitPython version: ${ver}"
+          curl "https://adafruit-circuit-python.s3.amazonaws.com/bin/mpy-cross/linux-amd64/mpy-cross-linux-amd64-${ver}.static" > mpy-cross
           chmod +x mpy-cross
 
       - name: Download and extract sources

--- a/.github/workflows/merge-libs-compile-circuitpython-files.yml
+++ b/.github/workflows/merge-libs-compile-circuitpython-files.yml
@@ -39,6 +39,7 @@ jobs:
           echo "CircuitPython version: ${ver}"
           curl "https://adafruit-circuit-python.s3.amazonaws.com/bin/mpy-cross/linux-amd64/mpy-cross-linux-amd64-${ver}.static" > mpy-cross
           chmod +x mpy-cross
+          ./mpy-cross --version
 
       - name: Download and extract sources
         env:

--- a/.github/workflows/merge-libs-compile-circuitpython-files.yml
+++ b/.github/workflows/merge-libs-compile-circuitpython-files.yml
@@ -34,6 +34,8 @@ jobs:
           prefix: sources
 
       - name: Download mpy-cross
+        env:
+          PLATFORM: ${{ matrix.platform }}
         run: |
           ver=$(eval echo "\$sources_circuitpython_${PLATFORM}")
           echo "CircuitPython version: ${ver}"


### PR DESCRIPTION
Match `mpy-cross` to CircuitPython version (to prepare for testing CircuitPython 9)