### PR TITLE
Update Adafruit libs

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -1,12 +1,12 @@
 {
     "dmcomm_python": "https://github.com/dmcomm/dmcomm-python/archive/refs/tags/v0.7.0.zip",
-    "adafruit_bundle": "https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/download/20221111/adafruit-circuitpython-bundle-8.x-mpy-20221111.zip",
+    "adafruit_bundle": "https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/download/20231121/adafruit-circuitpython-bundle-8.x-mpy-20231121.zip",
     "circuitpython_minimqtt": {
-        "nina": "https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/releases/download/5.5.1/adafruit-circuitpython-minimqtt-8.x-mpy-5.5.1.zip",
-        "picow": "https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/releases/download/7.3.2/adafruit-circuitpython-minimqtt-8.x-mpy-7.3.2.zip"
+        "nina": "https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/releases/download/7.4.4/adafruit-circuitpython-minimqtt-8.x-mpy-7.4.4.zip",
+        "picow": "https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/releases/download/7.4.4/adafruit-circuitpython-minimqtt-8.x-mpy-7.4.4.zip"
         },
     "circuitpython": {
-        "nina": "8.2.2",
-        "picow": "8.2.2"
+        "nina": "8.2.8",
+        "picow": "8.2.8"
         }
     } 

--- a/sources.json
+++ b/sources.json
@@ -6,7 +6,7 @@
         "picow": "https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/releases/download/7.4.4/adafruit-circuitpython-minimqtt-8.x-mpy-7.4.4.zip"
         },
     "circuitpython": {
-        "nina": "8.2.8",
-        "picow": "8.2.8"
+        "nina": "8.2.2",
+        "picow": "8.2.2"
         }
     } 


### PR DESCRIPTION
Updated Adafruit libs to 2023-11-21 and MiniMQTT to 7.4.4 on both "picow" and "nina". Nina issues seem resolved. From what they were saying, `esp32spi` got updated to behave more similarly to the `wifi` module.