### PR TITLE
Send version info with result / heartbeat

### DIFF
--- a/lib/wificom/main.py
+++ b/lib/wificom/main.py
@@ -562,6 +562,7 @@ def main(led_pwm):
 		ui.sound_on = settings.is_sound_on(default=config["sound_on"])
 	else:
 		ui.sound_on = config["sound_on"]
+	version.set_display(ui.has_display)
 
 	run_column = 0
 	if not ui.has_display:

--- a/lib/wificom/main.py
+++ b/lib/wificom/main.py
@@ -10,7 +10,6 @@ import os
 import random
 import traceback
 
-import board
 import digitalio
 import displayio
 import microcontroller
@@ -27,10 +26,10 @@ from wificom import modes
 from wificom import mqtt
 from wificom.mqtt import rtb
 from wificom import settings
+from wificom import version
 from wificom.import_secrets import secrets_imported, secrets_error, secrets_error_display
 from config import config
 import board_config
-import version_info
 
 LOG_FILENAME = "wificom_log.txt"
 LOG_FILENAME_OLD = "wificom_log_old.txt"
@@ -72,16 +71,6 @@ def serial_readline():
 	if serial_str == "":
 		return None
 	return serial_str
-
-def get_version_info():
-	'''
-	Convert version info to a TOML string.
-	'''
-	return f'''name = "{version_info.name}"\r
-version = "{version_info.version}"\r
-variant = "{version_info.variant}"\r
-circuitpython_version = "{os.uname().version}"\r
-circuitpython_board_id = "{board.board_id}"'''
 
 def execute_digirom(rom, do_led=True):
 	'''
@@ -132,7 +121,7 @@ def process_new_digirom(command):
 			return (COMMAND_P, "[pause]")
 		elif digirom.op == "I":
 			new_digirom_alert()
-			return (COMMAND_I, get_version_info())
+			return (COMMAND_I, version.toml())
 		else:
 			ui.beep_error()
 			return (COMMAND_ERROR, "NotImplementedError:op=" + digirom.op)
@@ -408,11 +397,7 @@ def display_info():
 	Display settings info.
 	'''
 	print("Running display_info")
-	version = version_info.version
-	if len(version) <= 12:
-		version = "WiFiCom: " + version
-	info_text =  f"{version}\nCP: {os.uname().version.split()[0]}\n{board.board_id}"
-	ui.display_text(info_text)
+	ui.display_text(version.onscreen())
 	while not ui.is_c_pressed():
 		pass
 	ui.beep_cancel()

--- a/lib/wificom/mqtt.py
+++ b/lib/wificom/mqtt.py
@@ -17,9 +17,6 @@ _mqtt_topic_identifier = secrets_user_uuid + '-' + secrets_device_uuid
 _mqtt_topic_input = _mqtt_io_prefix + _mqtt_topic_identifier + '/wificom-input'
 _mqtt_topic_output =  _mqtt_io_prefix + _mqtt_topic_identifier + "/wificom-output"
 
-_cached_digirom_output = version.dictionary()
-_cached_digirom_output["device_uuid"] = secrets_device_uuid
-
 class MQTT_data:  #pylint:disable=invalid-name
 	'''
 	Stores data for the MQTT connection.
@@ -30,6 +27,7 @@ class MQTT_data:  #pylint:disable=invalid-name
 		self.is_output_hidden = None
 		self.api_response = None
 		self.new_digirom = None
+		self.cached_digirom_output = None
 
 class RTB_data:  #pylint:disable=invalid-name
 	'''
@@ -79,6 +77,9 @@ def connect_to_mqtt(mqtt_client):
 	# Set up a callback for the topic/feed
 	mqtt_client.add_topic_callback(_mqtt_topic_input, on_app_feed_callback)
 
+	_data.cached_digirom_output = version.dictionary()
+	_data.cached_digirom_output["device_uuid"] = secrets_device_uuid
+
 	return True
 
 def loop():
@@ -105,10 +106,10 @@ def send_digirom_output(output):
 	'''
 
 	# update json object with output and application_id
-	_cached_digirom_output["application_uuid"] = _data.last_application_id
-	_cached_digirom_output["output"] = str(output)
+	_data.cached_digirom_output["application_uuid"] = _data.last_application_id
+	_data.cached_digirom_output["output"] = str(output)
 
-	mqtt_message_json = json.dumps(_cached_digirom_output)
+	mqtt_message_json = json.dumps(_data.cached_digirom_output)
 
 	if _data.mqtt_client.is_connected:
 		_data.mqtt_client.publish(_mqtt_topic_output, mqtt_message_json)

--- a/lib/wificom/version.py
+++ b/lib/wificom/version.py
@@ -8,6 +8,14 @@ import os
 import board
 import version_info
 
+_has_display = None
+def set_display(value):
+	'''
+	Set whether we have a display.
+	'''
+	global _has_display  #pylint:disable=global-statement
+	_has_display = value
+
 def dictionary():
 	'''
 	Convert version info to an OrderedDict.
@@ -17,14 +25,23 @@ def dictionary():
 	result["version"] = version_info.version
 	result["circuitpython_version"] = os.uname().version
 	result["circuitpython_board_id"] = board.board_id
+	result["has_display"] = _has_display
 	return result
+
+def _toml_value(value):
+	if value is True:
+		return 'true'
+	elif value is False:
+		return 'false'
+	else:
+		return f'"{value}"'
 
 def toml():
 	'''
 	Convert version info to a TOML string.
 	'''
 	dic = dictionary()
-	items = [f'{key} = "{dic[key]}"' for key in dic]
+	items = [f'{key} = {_toml_value(dic[key])}' for key in dic]
 	return "\r\n".join(items)
 
 def onscreen():

--- a/lib/wificom/version.py
+++ b/lib/wificom/version.py
@@ -1,0 +1,37 @@
+'''
+version.py
+Handles the version info (from version_info.py and system)
+'''
+
+import collections
+import os
+import board
+import version_info
+
+def dictionary():
+	'''
+	Convert version info to an OrderedDict.
+	'''
+	result = collections.OrderedDict()
+	result["name"] = version_info.name
+	result["version"] = version_info.version
+	result["circuitpython_version"] = os.uname().version
+	result["circuitpython_board_id"] = board.board_id
+	return result
+
+def toml():
+	'''
+	Convert version info to a TOML string.
+	'''
+	dic = dictionary()
+	items = [f'{key} = "{dic[key]}"' for key in dic]
+	return "\r\n".join(items)
+
+def onscreen():
+	'''
+	Create version info for display on the screen.
+	'''
+	version = version_info.version
+	if len(version) <= 12:
+		version = "WiFiCom: " + version
+	return f"{version}\nCP: {os.uname().version.split()[0]}\n{board.board_id}"


### PR DESCRIPTION
I can't see what's happening on the server so can you check that?

As part of this, refactored the version info that shows on the screen or is a result of "i" (wifi or serial).

Dropping "variant" from reported info - picow/nina bundles are going to be identical in the upcoming release, and dropping nina after.

Adding "has_display" to reported info for future server decisions.