### PR TITLE
Reduce MQTT timeout and connection attempts

### DIFF
--- a/lib/wificom/mqtt.py
+++ b/lib/wificom/mqtt.py
@@ -5,7 +5,6 @@ Handle MQTT connections, subscriptions, and callbacks
 
 # pylint: disable=unused-argument
 
-import time
 import json
 from wificom.import_secrets import secrets_mqtt_username, \
 secrets_device_uuid, \
@@ -55,18 +54,11 @@ def connect_to_mqtt(mqtt_client):
 	mqtt_client.on_unsubscribe = unsubscribe
 
 	# Connect to MQTT Broker
-	attempt = 0
-	while attempt < 3:
-		try:
-			print(f"Connecting to MQTT Broker (attempt {attempt+1})...")
-			mqtt_client.connect()
-			break
-		except Exception as e:  # pylint: disable=broad-except
-			print(f"Failed to connect to MQTT Broker: {type(e)} - {e}")
-			attempt += 1
-			time.sleep(1)
-	else:
-		print("Unable to connect to MQTT Broker after 3 attempts.")
+	try:
+		print("Connecting to MQTT Broker...")
+		mqtt_client.connect()
+	except Exception as e:  # pylint: disable=broad-except
+		print(f"Failed to connect to MQTT Broker: {repr(e)}")
 		return False
 
 	# Use mqtt_client to subscribe to the mqtt_topic_input feed

--- a/lib/wificom/wifi_nina.py
+++ b/lib/wificom/wifi_nina.py
@@ -41,6 +41,8 @@ class Wifi:
 						broker=secrets_mqtt_broker,
 						username=secrets_mqtt_username.lower(),
 						password=secrets_mqtt_password,
+						keep_alive=15,
+						connect_retries=3,
 					)
 
 					MQTT.set_socket(socket, self.esp)

--- a/lib/wificom/wifi_picow.py
+++ b/lib/wificom/wifi_picow.py
@@ -64,6 +64,8 @@ class Wifi:
 			password=secrets_mqtt_password,
 			socket_pool=pool,
 			ssl_context=ssl.create_default_context(),
+			keep_alive=15,
+			connect_retries=3,
 		)
 
 		return mqtt_client


### PR DESCRIPTION
The minimqtt update changed retry behaviour so that ours was excessive.

For me, keep_alive=15 is detecting hotspot turned off after about 25-30 seconds on PicoW and somewhat less on Nina (Nina was detecting it much quicker before anyway so must also have some other way).