### PR TITLE
Change build to use new sources.json

### DIFF
--- a/.github/workflows/merge-libs-compile-circuitpython-files.yml
+++ b/.github/workflows/merge-libs-compile-circuitpython-files.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        build: [default, circpy9, circpy10]
+        build: [default]
 
     steps:
       - uses: actions/checkout@v3

--- a/sources.json
+++ b/sources.json
@@ -1,23 +1,11 @@
 {
   "boards": {
-    "raspberry_pi_pico2_w": "circpy10",
-    "seeeduino_xiao_rp2040": "circpy9"
   },
   "builds": {
     "default": {
       "circuitpython": "8.2.2",
       "dmcomm_python": "https://github.com/dmcomm/dmcomm-python/archive/refs/tags/v0.9.0.zip",
       "adafruit_bundle": "https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/download/20231121/adafruit-circuitpython-bundle-8.x-mpy-20231121.zip"
-    },
-    "circpy10": {
-      "circuitpython": "10.0.0-alpha.6",
-      "dmcomm_python": "https://github.com/dmcomm/dmcomm-python/archive/refs/tags/v0.9.0.zip",
-      "adafruit_bundle": "https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/download/20250409/adafruit-circuitpython-bundle-10.x-mpy-20250409.zip"
-    },
-    "circpy9": {
-      "circuitpython": "9.2.7",
-      "dmcomm_python": "https://github.com/dmcomm/dmcomm-python/archive/refs/tags/v0.9.0.zip",
-      "adafruit_bundle": "https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/download/20250409/adafruit-circuitpython-bundle-9.x-mpy-20250409.zip"
     }
   }
 }


### PR DESCRIPTION
Note the full example is at https://github.com/mechawrench/wificom-lib/blob/a7eaa02b34858ab899a2efe12643bfac7138dc3d/sources.json (extra builds removed until needed).