### PR TITLE
Configure start timing for turn 1 digiroms

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -158,6 +158,7 @@ disable=raw-checker-failed,
         too-few-public-methods,
         no-name-in-module,
         too-many-arguments,
+        too-many-instance-attributes,
         no-else-break,
         no-else-return,
 

--- a/lib/wificom/main.py
+++ b/lib/wificom/main.py
@@ -350,15 +350,28 @@ def run_serial():
 				digirom = output
 				print(f"{digirom.signal_type}{digirom.turn}-[{len(digirom)} packets]")
 				status_display.do(digirom)
-				time.sleep(1)
+				time.sleep(settings.initial_delay(digirom.turn, True))
 			elif command_type in [COMMAND_ERROR, COMMAND_P, COMMAND_I]:
 				print(output)
 				status_display.do("Paused")
 		if digirom is not None:
-			execute_digirom(digirom)
-			seconds_passed = time.monotonic() - time_start
-			if seconds_passed < 5:
-				time.sleep(5 - seconds_passed)
+			was_c_pressed = False
+			timed_out = False
+			if digirom.turn == 1 and settings.turn_1_button:
+				while True:
+					if ui.is_b_pressed(True):
+						break
+					if ui.is_c_pressed():
+						was_c_pressed = True
+						break
+					if time.monotonic() - time_start > 5:
+						timed_out = True
+						break
+			if not was_c_pressed and not timed_out:
+				execute_digirom(digirom)
+				seconds_passed = time.monotonic() - time_start
+				if seconds_passed < 5:
+					time.sleep(5 - seconds_passed)
 		else:
 			time.sleep(0.1)  # Just waiting for serial
 

--- a/lib/wificom/main.py
+++ b/lib/wificom/main.py
@@ -486,14 +486,14 @@ def pick_delay():
 	'''
 	Pick turn 1 delay from the menu.
 	'''
-	(current_index, values) = settings.turn_1_delay_options()
+	values = settings.turn_1_delay_options()
 	names = []
 	for value in values:
 		if value < 0:
 			names.append("Button")
 		else:
 			names.append(f"{value} seconds")
-	settings.turn_1_delay = ui.menu(names, values, values[current_index], current_index)
+	settings.turn_1_delay = ui.menu(names, values, values[0])
 
 def save_settings():
 	'''

--- a/lib/wificom/main.py
+++ b/lib/wificom/main.py
@@ -114,6 +114,38 @@ def execute_digirom(rom, do_led=True, do_beep=True):
 		ui.led_dim()
 	return result
 
+def execute_digirom_loop(rom, is_wifi):
+	'''
+	Handle digirom execution timing etc.
+	'''
+	time_start = time.monotonic()
+	loop_time = 5
+	was_c_pressed = False
+	button_timed_out = False
+	if rom.turn == 1 and settings.turn_1_button:
+		while True:
+			if ui.is_b_pressed(True):
+				break
+			if ui.is_c_pressed():
+				was_c_pressed = True
+				break
+			if time.monotonic() - time_start > loop_time:
+				button_timed_out = True
+				break
+	result = None
+	if not button_timed_out and not was_c_pressed:
+		result = execute_digirom(rom)
+	if is_wifi and not was_c_pressed:
+		mqtt.send_digirom_output(result)
+		ui.led_off()
+		mqtt.loop()
+		ui.led_dim()
+		if mqtt.get_subscribed_output(False) is not None:
+			return
+	seconds_passed = time.monotonic() - time_start
+	if seconds_passed < loop_time:
+		time.sleep(loop_time - seconds_passed)
+
 def process_new_digirom(command):
 	'''
 	Parse the command and show success/failure.
@@ -225,7 +257,7 @@ def run_wifi():
 	'''
 	Do the normal WiFiCom things.
 	'''
-	# pylint: disable=too-many-branches,too-many-statements,too-many-locals
+	# pylint: disable=too-many-branches,too-many-statements
 
 	print("Running WiFi")
 	gc.collect()
@@ -274,6 +306,7 @@ def run_wifi():
 			if command_type == COMMAND_DIGIROM:
 				digirom = output
 				status_display.do(digirom)
+				time.sleep(settings.initial_delay(digirom.turn, False))
 			elif command_type in [COMMAND_ERROR, COMMAND_P, COMMAND_I]:
 				print(output)
 				mqtt.send_digirom_output(output)
@@ -309,22 +342,17 @@ def run_wifi():
 			if rtb_was_active:
 				ui.led_dim()
 			rtb_was_active = False
-			last_output = None
 			if digirom is not None:
-				result = execute_digirom(digirom)
-				if len(result) >= 1:
-					last_output = result
-
-			# Send to MQTT topic (acts as a ping also)
-			mqtt.send_digirom_output(last_output)
-
-			while True:
-				mqtt.loop()
-				if mqtt.get_subscribed_output(False) is not None:
-					break
-				if time.monotonic() - time_start >= 5:
-					break
-				time.sleep(0.1)
+				execute_digirom_loop(digirom, True)
+			else:
+				mqtt.send_digirom_output(None)  # Ping
+				while True:
+					mqtt.loop()
+					if mqtt.get_subscribed_output(False) is not None:
+						break
+					if time.monotonic() - time_start >= 5:
+						break
+					time.sleep(0.1)
 		status_display.redraw()
 	mqtt.quit_rtb()
 
@@ -339,7 +367,6 @@ def run_serial():
 	digirom = None
 	status_display.change("Serial", "Hold C to exit", "Paused", show_battery=False)
 	while not ui.is_c_pressed():
-		time_start = time.monotonic()
 		serial_str = serial_readline()
 		if serial_str is not None:
 			digirom = None
@@ -355,23 +382,7 @@ def run_serial():
 				print(output)
 				status_display.do("Paused")
 		if digirom is not None:
-			was_c_pressed = False
-			timed_out = False
-			if digirom.turn == 1 and settings.turn_1_button:
-				while True:
-					if ui.is_b_pressed(True):
-						break
-					if ui.is_c_pressed():
-						was_c_pressed = True
-						break
-					if time.monotonic() - time_start > 5:
-						timed_out = True
-						break
-			if not was_c_pressed and not timed_out:
-				execute_digirom(digirom)
-				seconds_passed = time.monotonic() - time_start
-				if seconds_passed < 5:
-					time.sleep(5 - seconds_passed)
+			execute_digirom_loop(digirom, False)
 		else:
 			time.sleep(0.1)  # Just waiting for serial
 
@@ -410,11 +421,7 @@ def run_punchbag():
 				# want to use node.text too ?
 				status_display.change("Punchbag", "Hold C to change", rom)
 				while not ui.is_c_pressed():
-					time_start = time.monotonic()
-					execute_digirom(rom)
-					seconds_passed = time.monotonic() - time_start
-					if seconds_passed < 5:
-						time.sleep(5 - seconds_passed)
+					execute_digirom_loop(rom, False)
 					status_display.redraw()
 				ui.beep_cancel()
 				ui.display_text("Exiting\n(Release button)")

--- a/lib/wificom/main.py
+++ b/lib/wificom/main.py
@@ -441,6 +441,7 @@ def run_settings():
 	settings_menu_configs = [
 		("Version Info", display_info),
 		("TOGGLE_SOUND", toggle_sound),
+		("Turn 1 delay", pick_delay),
 	]
 	if startup_mode == modes.MODE_DEV:
 		settings_menu_configs.append(("(Dev Mode no drive)", None))
@@ -480,6 +481,19 @@ def toggle_sound():
 		settings.sound_on = True
 		ui.sound_on = True
 		ui.beep_ready()
+
+def pick_delay():
+	'''
+	Pick turn 1 delay from the menu.
+	'''
+	(current_index, values) = settings.turn_1_delay_options()
+	names = []
+	for value in values:
+		if value < 0:
+			names.append("Button")
+		else:
+			names.append(f"{value} seconds")
+	settings.turn_1_delay = ui.menu(names, values, values[current_index], current_index)
 
 def save_settings():
 	'''

--- a/lib/wificom/main.py
+++ b/lib/wificom/main.py
@@ -441,7 +441,7 @@ def run_settings():
 	settings_menu_configs = [
 		("Version Info", display_info),
 		("TOGGLE_SOUND", toggle_sound),
-		("Turn 1 delay", pick_delay),
+		("Turn 1 Delay", pick_delay),
 	]
 	if startup_mode == modes.MODE_DEV:
 		settings_menu_configs.append(("(Dev Mode no drive)", None))
@@ -490,7 +490,7 @@ def pick_delay():
 	names = []
 	for value in values:
 		if value < 0:
-			names.append("Button")
+			names.append("Button Press")
 		else:
 			names.append(f"{value} seconds")
 	settings.turn_1_delay = ui.menu(names, values, values[0])

--- a/lib/wificom/main.py
+++ b/lib/wificom/main.py
@@ -124,7 +124,7 @@ def execute_digirom_loop(rom, is_wifi):
 	button_timed_out = False
 	if rom.turn == 1 and settings.turn_1_button:
 		while True:
-			if ui.is_b_pressed(True):
+			if ui.is_a_pressed() or ui.is_b_pressed(True):
 				break
 			if ui.is_c_pressed():
 				was_c_pressed = True
@@ -669,7 +669,7 @@ def main(led_pwm):
 	displayio.release_displays()
 	ui = wificom.ui.UserInterface(**board_config.ui_pins, led_pwm=led_pwm)
 	ui.sound_on = settings.sound_on
-	status_display = wificom.status.StatusDisplay(ui, setup_battery_monitor())
+	status_display = wificom.status.StatusDisplay(ui, settings, setup_battery_monitor())
 	version.set_display(ui.has_display)
 
 	run_column = 0 if mode_was_requested else 1

--- a/lib/wificom/main.py
+++ b/lib/wificom/main.py
@@ -685,6 +685,7 @@ def main(led_pwm):
 	ui.sound_on = settings.sound_on
 	status_display = wificom.status.StatusDisplay(ui, settings, setup_battery_monitor())
 	version.set_display(ui.has_display)
+	version.set_settings(settings)
 
 	run_column = 0 if mode_was_requested else 1
 	branches = {

--- a/lib/wificom/realtime.py
+++ b/lib/wificom/realtime.py
@@ -14,7 +14,6 @@ STATUS_PUSH = 2
 _MESSAGE_EXPIRY_TIME = 30
 
 class RealTime:
-	#pylint: disable=too-many-instance-attributes
 	'''
 	Abstract base class for real-time battles.
 

--- a/lib/wificom/settings.py
+++ b/lib/wificom/settings.py
@@ -5,6 +5,12 @@ Handles the stored settings.
 
 import json
 
+def tenths(value):
+	'''
+	Convert float to integer number of tenths.
+	'''
+	return round(value * 10)
+
 class Settings:
 	'''
 	Stores settings.
@@ -83,6 +89,8 @@ class Settings:
 		return self._sound_on
 	@sound_on.setter
 	def sound_on(self, value):
+		if self._sound_on == value:
+			return
 		self._sound_on = value
 		self._changed = True
 	@property
@@ -100,6 +108,8 @@ class Settings:
 		return self._turn_1_delay
 	@turn_1_delay.setter
 	def turn_1_delay(self, value):
+		if tenths(self._turn_1_delay) == tenths(value):
+			return
 		self._turn_1_delay = value
 		self._changed = True
 	def turn_1_delay_options(self):
@@ -108,9 +118,9 @@ class Settings:
 		Current value is first, added if not already present.
 		'''
 		current = self._turn_1_delay
-		current_tenths = round(current * 10)
+		current_tenths = tenths(current)
 		options = self._turn_1_delay_options
-		options_tenths = [round(opt * 10) for opt in options]
+		options_tenths = [tenths(opt) for opt in options]
 		try:
 			i = options_tenths.index(current_tenths)
 			options = options[:i] + options[i+1:]  # Remove current

--- a/lib/wificom/settings.py
+++ b/lib/wificom/settings.py
@@ -3,8 +3,6 @@ settings.py
 Handles the stored settings.
 '''
 
-#pylint:disable=too-many-instance-attributes
-
 import json
 
 class Settings:

--- a/lib/wificom/settings.py
+++ b/lib/wificom/settings.py
@@ -6,6 +6,7 @@ Handles the stored settings.
 import json
 
 class Settings:
+	#pylint:disable=too-many-instance-attributes
 	'''
 	Stores settings.
 	Init: load json file from filepath. Try to save it if not present.

--- a/lib/wificom/settings.py
+++ b/lib/wificom/settings.py
@@ -14,6 +14,8 @@ class Settings:
 	def __init__(self, filepath):
 		self._filepath = filepath
 		self._sound_on = True
+		self._turn_1_delay = 1
+		self._turn_1_button = False
 		self._try_write = True
 		self._changed = False
 		self.error = None
@@ -21,6 +23,9 @@ class Settings:
 			with open(self._filepath, encoding="utf-8") as json_file:
 				data = json.load(json_file)
 			self._sound_on = data.get("sound_on", True)
+			self._turn_1_delay = data.get("turn_1_delay", 1)
+			#TODO validate
+			self._turn_1_button = data.get("turn_1_button", False)
 		except OSError as e:
 			if e.errno == 2:
 				self._changed = True
@@ -43,7 +48,11 @@ class Settings:
 		if not self._try_write:
 			self.error = "Not overwriting bad file"
 			return True
-		data = {"sound_on": self._sound_on}
+		data = {
+			"sound_on": self._sound_on,
+			"turn_1_delay": self._turn_1_delay,
+			"turn_1_button": self._turn_1_button,
+		}
 		try:
 			with open(self._filepath, "w", encoding="utf-8") as json_file:
 				json.dump(data, json_file)
@@ -61,3 +70,34 @@ class Settings:
 	def sound_on(self, value):
 		self._sound_on = value
 		self._changed = True
+	@property
+	def turn_1_delay(self):
+		'''
+		Delay in seconds between receiving a turn 1 digirom and first execution.
+		Ignored if turn_1_button is True.
+		'''
+		return self._turn_1_delay
+	@turn_1_delay.setter
+	def turn_1_delay(self, value):
+		self._turn_1_delay = value
+		self._changed = True
+	@property
+	def turn_1_button(self):
+		'''
+		Whether user presses the button for a turn 1 digirom.
+		'''
+		return self._turn_1_button
+	@turn_1_button.setter
+	def turn_1_button(self, value):
+		self._turn_1_button = value
+		self._changed = True
+	def initial_delay(self, turn, on_serial):
+		'''
+		Delay before first execution of new digirom.
+		'''
+		delay = self.turn_1_delay
+		if turn != 1 or self.turn_1_button:
+			delay = 0
+		if delay < 1 and on_serial:
+			delay = 1
+		return delay

--- a/lib/wificom/settings.py
+++ b/lib/wificom/settings.py
@@ -26,6 +26,7 @@ class Settings:
 			self._turn_1_delay = data.get("turn_1_delay", 1)
 			#TODO validate
 			self._turn_1_button = data.get("turn_1_button", False)
+			#TODO write file if new settings were created
 		except OSError as e:
 			if e.errno == 2:
 				self._changed = True

--- a/lib/wificom/status.py
+++ b/lib/wificom/status.py
@@ -40,11 +40,13 @@ class BatteryMonitor:
 		return "[" + "=" * filled + " " * unfilled + "]"
 
 class StatusDisplay:
+	#pylint:disable=too-many-instance-attributes
 	'''
 	Handles status display for WiFi/Serial/Punchbag.
 	'''
-	def __init__(self, ui, battery_monitor):  #pylint:disable=invalid-name
+	def __init__(self, ui, settings, battery_monitor):  #pylint:disable=invalid-name
 		self._ui = ui
+		self._settings = settings
 		self._battery_monitor = battery_monitor
 		self._mode = ""
 		self._desc = None
@@ -66,10 +68,16 @@ class StatusDisplay:
 		Set status and redraw trying digirom then string.
 		'''
 		try:
-			guide = "wait for start" if status.turn == 1 else "push vpet button"
+			if status.turn == 1:
+				if self._settings.turn_1_button:
+					guide = "push com button"
+				else:
+					guide = "wait for start"
+			else:
+				guide = "push vpet button"
 			status = f"{status.signal_type}{status.turn}: {guide}"
 		except AttributeError:
-			pass
+			pass  # Not a digirom, treat as string
 		self._status = status
 		self.redraw()
 	def redraw(self):

--- a/lib/wificom/status.py
+++ b/lib/wificom/status.py
@@ -40,7 +40,6 @@ class BatteryMonitor:
 		return "[" + "=" * filled + " " * unfilled + "]"
 
 class StatusDisplay:
-	#pylint:disable=too-many-instance-attributes
 	'''
 	Handles status display for WiFi/Serial/Punchbag.
 	'''

--- a/lib/wificom/ui.py
+++ b/lib/wificom/ui.py
@@ -185,13 +185,14 @@ class UserInterface:
 		if self._led is not None:
 			self._led.frequency = 1
 			self._led.duty_cycle = 0x8000
-	def menu(self, options, results, cancel_result, selection=0):
+	def menu(self, options, results, cancel_result):
 		'''
 		Display a menu with the specified options and return the corresponding result.
 
 		If a result is None, that option cannot be activated.
 		Should only be called if there is a screen.
 		'''
+		selection = 0
 		while True:
 			text_rows = make_menu_text(options, selection)
 			self.display_rows(text_rows)

--- a/lib/wificom/ui.py
+++ b/lib/wificom/ui.py
@@ -185,14 +185,13 @@ class UserInterface:
 		if self._led is not None:
 			self._led.frequency = 1
 			self._led.duty_cycle = 0x8000
-	def menu(self, options, results, cancel_result):
+	def menu(self, options, results, cancel_result, selection=0):
 		'''
 		Display a menu with the specified options and return the corresponding result.
 
 		If a result is None, that option cannot be activated.
 		Should only be called if there is a screen.
 		'''
-		selection = 0
 		while True:
 			text_rows = make_menu_text(options, selection)
 			self.display_rows(text_rows)

--- a/lib/wificom/ui.py
+++ b/lib/wificom/ui.py
@@ -23,7 +23,6 @@ class UserInterface:
 	'''
 	Handles the screen, buttons, menus, speaker and LED.
 	'''
-	#pylint:disable=too-many-instance-attributes
 	def __init__(self, display_scl, display_sda, button_a, button_b, button_c, speaker, led_pwm):
 		self._display = None
 		self.display_error = None

--- a/lib/wificom/version.py
+++ b/lib/wificom/version.py
@@ -16,6 +16,14 @@ def set_display(value):
 	global _has_display  #pylint:disable=global-statement
 	_has_display = value
 
+_settings = None
+def set_settings(obj):
+	'''
+	Link the settings object.
+	'''
+	global _settings  #pylint:disable=global-statement
+	_settings = obj
+
 def dictionary():
 	'''
 	Convert version info to an OrderedDict.
@@ -26,6 +34,8 @@ def dictionary():
 	result["circuitpython_version"] = os.uname().version
 	result["circuitpython_board_id"] = board.board_id
 	result["has_display"] = _has_display
+	if _settings is not None:
+		result["turn_1_button"] = _settings.turn_1_button
 	return result
 
 def _toml_value(value):

--- a/lib/wificom/wifi_picow.py
+++ b/lib/wificom/wifi_picow.py
@@ -66,7 +66,7 @@ class Wifi:
 			ssl_context=ssl.create_default_context(),
 			keep_alive=15,
 			connect_retries=3,
-			#socket_timeout=0.3,
+			#socket_timeout=0.3,  # Waiting for lib update
 		)
 
 		return mqtt_client

--- a/lib/wificom/wifi_picow.py
+++ b/lib/wificom/wifi_picow.py
@@ -66,6 +66,7 @@ class Wifi:
 			ssl_context=ssl.create_default_context(),
 			keep_alive=15,
 			connect_retries=3,
+			#socket_timeout=0.3,
 		)
 
 		return mqtt_client


### PR DESCRIPTION
New config settings "turn_1_delay" (float) and "turn_1_delay_options" (list of floats). Positive number is time in seconds between new turn-1 digirom received and first transmission, though serial mode keeps a minimum of 1. Negative number means wait for button press of A or B on wificom (button C on P-Com). "turn_1_delay" is settable via settings menu using the list from "turn_1_delay_options". "turn_1_button" (bool) added to info TOML. When on wifi, LED turns off during mqtt loop to indicated wificom unresponsive.